### PR TITLE
Add API key auth, article draft system, and Intercom publish flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,7 @@ NOTION_STORING_DATABASE_ID=
 # Google OAuth (required for authentication)
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+
+# Intercom (required for article publishing)
+INTERCOM_ACCESS_TOKEN=
+INTERCOM_WORKSPACE_ID=

--- a/app/(chat)/api/api-keys/route.ts
+++ b/app/(chat)/api/api-keys/route.ts
@@ -1,0 +1,87 @@
+import { auth } from '@/app/(auth)/auth';
+import { generateApiKey, hashApiKey, getKeyPrefix } from '@/lib/api-key';
+import {
+  createApiKeyRecord,
+  getApiKeysByUserId,
+  revokeApiKey,
+} from '@/lib/db/queries';
+import { ChatSDKError } from '@/lib/errors';
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new ChatSDKError('unauthorized:chat').toResponse();
+  }
+
+  const keys = await getApiKeysByUserId({ userId: session.user.id });
+
+  return Response.json(
+    keys.map((k) => ({
+      id: k.id,
+      name: k.name,
+      keyPrefix: k.keyPrefix,
+      createdAt: k.createdAt,
+      expiresAt: k.expiresAt,
+      lastUsedAt: k.lastUsedAt,
+      revokedAt: k.revokedAt,
+    })),
+  );
+}
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new ChatSDKError('unauthorized:chat').toResponse();
+  }
+
+  const body = await request.json();
+  const name = body.name?.trim();
+
+  if (!name || name.length === 0) {
+    return Response.json({ error: 'Name is required' }, { status: 400 });
+  }
+
+  const plainKey = generateApiKey();
+  const keyHash = hashApiKey(plainKey);
+  const keyPrefix = getKeyPrefix(plainKey);
+
+  const record = await createApiKeyRecord({
+    userId: session.user.id,
+    name,
+    keyHash,
+    keyPrefix,
+    expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
+  });
+
+  // Return the full plaintext key — this is the only time it's shown
+  return Response.json({
+    id: record.id,
+    name: record.name,
+    keyPrefix: record.keyPrefix,
+    key: plainKey,
+    createdAt: record.createdAt,
+    expiresAt: record.expiresAt,
+  });
+}
+
+export async function DELETE(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new ChatSDKError('unauthorized:chat').toResponse();
+  }
+
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get('id');
+
+  if (!id) {
+    return Response.json({ error: 'Key ID is required' }, { status: 400 });
+  }
+
+  const result = await revokeApiKey({ id, userId: session.user.id });
+
+  if (!result) {
+    return Response.json({ error: 'Key not found' }, { status: 404 });
+  }
+
+  return Response.json({ success: true });
+}

--- a/app/(chat)/api/history/route.ts
+++ b/app/(chat)/api/history/route.ts
@@ -1,7 +1,7 @@
-import { auth } from '@/app/(auth)/auth';
 import type { NextRequest } from 'next/server';
 import { getChatsByUserId } from '@/lib/db/queries';
 import { ChatSDKError } from '@/lib/errors';
+import { getAuthenticatedUser } from '@/lib/auth-helpers';
 
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
@@ -17,14 +17,14 @@ export async function GET(request: NextRequest) {
     ).toResponse();
   }
 
-  const session = await auth();
+  const authResult = await getAuthenticatedUser();
 
-  if (!session?.user) {
+  if (!authResult) {
     return new ChatSDKError('unauthorized:chat').toResponse();
   }
 
   const chats = await getChatsByUserId({
-    id: session.user.id,
+    id: authResult.userId,
     limit,
     startingAfter,
     endingBefore,

--- a/app/(chat)/settings/page.tsx
+++ b/app/(chat)/settings/page.tsx
@@ -1,0 +1,24 @@
+import { auth } from '@/app/(auth)/auth';
+import { redirect } from 'next/navigation';
+import { ApiKeysManager } from '@/components/api-keys-manager';
+
+export default async function SettingsPage() {
+  const session = await auth();
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  return (
+    <div className="flex items-start justify-center min-h-dvh bg-background py-12 px-4">
+      <div className="w-full max-w-2xl flex flex-col gap-8">
+        <div>
+          <h1 className="text-2xl font-semibold dark:text-zinc-50">Settings</h1>
+          <p className="text-sm text-gray-500 dark:text-zinc-400 mt-1">
+            Manage your API keys for programmatic access
+          </p>
+        </div>
+        <ApiKeysManager />
+      </div>
+    </div>
+  );
+}

--- a/app/api/drafts/[id]/discard/route.ts
+++ b/app/api/drafts/[id]/discard/route.ts
@@ -1,0 +1,34 @@
+import { getAuthenticatedUser } from '@/lib/auth-helpers';
+import { getArticleDraft, updateArticleDraft } from '@/lib/db/queries';
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authResult = await getAuthenticatedUser();
+  if (!authResult) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const draft = await getArticleDraft({ id });
+
+  if (!draft) {
+    return Response.json({ error: 'Draft not found' }, { status: 404 });
+  }
+
+  if (draft.userId !== authResult.userId) {
+    return Response.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  if (draft.status !== 'draft') {
+    return Response.json(
+      { error: `Draft is already ${draft.status}` },
+      { status: 400 },
+    );
+  }
+
+  await updateArticleDraft({ id: draft.id, status: 'discarded' });
+
+  return Response.json({ success: true });
+}

--- a/app/api/drafts/[id]/publish/route.ts
+++ b/app/api/drafts/[id]/publish/route.ts
@@ -1,0 +1,116 @@
+import { getAuthenticatedUser } from '@/lib/auth-helpers';
+import { getArticleDraft, updateArticleDraft } from '@/lib/db/queries';
+import { markdownToHtml } from '@/lib/intercom/markdown-to-html';
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authResult = await getAuthenticatedUser();
+  if (!authResult) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const draft = await getArticleDraft({ id });
+
+  if (!draft) {
+    return Response.json({ error: 'Draft not found' }, { status: 404 });
+  }
+
+  if (draft.userId !== authResult.userId) {
+    return Response.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  if (draft.status !== 'draft') {
+    return Response.json(
+      { error: `Draft is already ${draft.status}` },
+      { status: 400 },
+    );
+  }
+
+  const accessToken = process.env.INTERCOM_ACCESS_TOKEN;
+  const workspaceId = process.env.INTERCOM_WORKSPACE_ID;
+
+  if (!accessToken || !workspaceId) {
+    return Response.json(
+      { error: 'Intercom not configured' },
+      { status: 500 },
+    );
+  }
+
+  // Convert markdown to HTML for Intercom
+  const htmlContent = await markdownToHtml(draft.content);
+
+  // Fetch admins to use first available as author
+  const adminsRes = await fetch('https://api.intercom.io/admins', {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/json',
+      'Intercom-Version': '2.14',
+    },
+  });
+
+  let authorId: number | undefined;
+  if (adminsRes.ok) {
+    const adminsData = await adminsRes.json();
+    const admins = adminsData.admins || [];
+    if (admins.length > 0) {
+      authorId = admins[0].id;
+    }
+  }
+
+  if (!authorId) {
+    return Response.json(
+      { error: 'No Intercom admin found to set as author' },
+      { status: 500 },
+    );
+  }
+
+  // Create as draft in Intercom (not published — CS can review there too)
+  const articlePayload: Record<string, unknown> = {
+    title: draft.title,
+    body: htmlContent,
+    author_id: authorId,
+    state: 'draft',
+  };
+
+  if (draft.description) {
+    articlePayload.description = draft.description.slice(0, 255);
+  }
+
+  const response = await fetch('https://api.intercom.io/articles', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'Intercom-Version': '2.14',
+    },
+    body: JSON.stringify(articlePayload),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    console.error('Intercom publish error:', errorData);
+    return Response.json(
+      { error: 'Failed to publish to Intercom', details: errorData },
+      { status: response.status },
+    );
+  }
+
+  const articleData = await response.json();
+
+  // Update draft status
+  await updateArticleDraft({
+    id: draft.id,
+    status: 'published',
+    intercomArticleId: String(articleData.id),
+  });
+
+  return Response.json({
+    success: true,
+    intercomArticleId: articleData.id,
+    intercomUrl: `https://app.intercom.com/a/apps/${workspaceId}/articles/${articleData.id}`,
+  });
+}

--- a/app/api/drafts/[id]/publish/route.ts
+++ b/app/api/drafts/[id]/publish/route.ts
@@ -3,7 +3,7 @@ import { getArticleDraft, updateArticleDraft } from '@/lib/db/queries';
 import { markdownToHtml } from '@/lib/intercom/markdown-to-html';
 
 export async function POST(
-  _request: Request,
+  request: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const authResult = await getAuthenticatedUser();
@@ -39,35 +39,53 @@ export async function POST(
     );
   }
 
-  // Convert markdown to HTML for Intercom
-  const htmlContent = await markdownToHtml(draft.content);
-
-  // Fetch admins to use first available as author
-  const adminsRes = await fetch('https://api.intercom.io/admins', {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      Accept: 'application/json',
-      'Intercom-Version': '2.14',
-    },
-  });
-
+  // Parse optional body params for collection and author selection
+  let collectionId: string | undefined;
   let authorId: number | undefined;
-  if (adminsRes.ok) {
-    const adminsData = await adminsRes.json();
-    const admins = adminsData.admins || [];
-    if (admins.length > 0) {
-      authorId = admins[0].id;
+  let description: string | undefined;
+
+  try {
+    const body = await request.json();
+    collectionId = body.collectionId;
+    if (body.authorId) authorId = Number.parseInt(body.authorId);
+    if (body.description !== undefined) description = body.description;
+  } catch {
+    // Empty body is fine — we'll fall back to defaults
+  }
+
+  // Use description from body, or fall back to draft description
+  const finalDescription = (description ?? draft.description)?.slice(0, 255);
+
+  // If no author provided, fetch first available admin as fallback
+  if (!authorId) {
+    const adminsRes = await fetch('https://api.intercom.io/admins', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/json',
+        'Intercom-Version': '2.14',
+      },
+    });
+
+    if (adminsRes.ok) {
+      const adminsData = await adminsRes.json();
+      const admins = adminsData.admins || [];
+      if (admins.length > 0) {
+        authorId = admins[0].id;
+      }
+    }
+
+    if (!authorId) {
+      return Response.json(
+        { error: 'No Intercom admin found to set as author' },
+        { status: 500 },
+      );
     }
   }
 
-  if (!authorId) {
-    return Response.json(
-      { error: 'No Intercom admin found to set as author' },
-      { status: 500 },
-    );
-  }
+  // Convert markdown to HTML for Intercom
+  const htmlContent = await markdownToHtml(draft.content);
 
-  // Create as draft in Intercom (not published — CS can review there too)
+  // Build article payload — always creates as draft in Intercom for CS review
   const articlePayload: Record<string, unknown> = {
     title: draft.title,
     body: htmlContent,
@@ -75,8 +93,14 @@ export async function POST(
     state: 'draft',
   };
 
-  if (draft.description) {
-    articlePayload.description = draft.description.slice(0, 255);
+  // Place in a collection if specified (help center article)
+  if (collectionId) {
+    articlePayload.parent_type = 'collection';
+    articlePayload.parent_id = Number.parseInt(collectionId);
+  }
+
+  if (finalDescription) {
+    articlePayload.description = finalDescription;
   }
 
   const response = await fetch('https://api.intercom.io/articles', {

--- a/app/api/drafts/[id]/route.ts
+++ b/app/api/drafts/[id]/route.ts
@@ -1,0 +1,64 @@
+import { getAuthenticatedUser } from '@/lib/auth-helpers';
+import { getArticleDraft, updateArticleDraft } from '@/lib/db/queries';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authResult = await getAuthenticatedUser();
+  if (!authResult) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const draft = await getArticleDraft({ id });
+
+  if (!draft) {
+    return Response.json({ error: 'Draft not found' }, { status: 404 });
+  }
+
+  if (draft.userId !== authResult.userId) {
+    return Response.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  return Response.json(draft);
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authResult = await getAuthenticatedUser();
+  if (!authResult) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const draft = await getArticleDraft({ id });
+
+  if (!draft) {
+    return Response.json({ error: 'Draft not found' }, { status: 404 });
+  }
+
+  if (draft.userId !== authResult.userId) {
+    return Response.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  if (draft.status !== 'draft') {
+    return Response.json(
+      { error: `Cannot edit a ${draft.status} draft` },
+      { status: 400 },
+    );
+  }
+
+  const body = await request.json();
+  const updates: Parameters<typeof updateArticleDraft>[0] = { id };
+
+  if (body.title !== undefined) updates.title = body.title;
+  if (body.content !== undefined) updates.content = body.content;
+  if (body.description !== undefined) updates.description = body.description;
+
+  const updated = await updateArticleDraft(updates);
+
+  return Response.json(updated);
+}

--- a/app/api/drafts/route.ts
+++ b/app/api/drafts/route.ts
@@ -1,0 +1,50 @@
+import { getAuthenticatedUser } from '@/lib/auth-helpers';
+import { createArticleDraft, getArticleDraftsByUserId } from '@/lib/db/queries';
+
+export async function GET() {
+  const authResult = await getAuthenticatedUser();
+  if (!authResult) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const drafts = await getArticleDraftsByUserId({
+    userId: authResult.userId,
+  });
+
+  return Response.json({ drafts });
+}
+
+export async function POST(request: Request) {
+  const authResult = await getAuthenticatedUser();
+  if (!authResult) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { title, content, description } = body;
+
+  if (!title?.trim() || !content?.trim()) {
+    return Response.json(
+      { error: 'Title and content are required' },
+      { status: 400 },
+    );
+  }
+
+  const draft = await createArticleDraft({
+    userId: authResult.userId,
+    title: title.trim(),
+    content: content.trim(),
+    description: description?.trim()?.slice(0, 255),
+  });
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL
+    || process.env.VERCEL_URL
+      ? `https://${process.env.VERCEL_URL}`
+      : 'http://localhost:3000';
+
+  return Response.json({
+    id: draft.id,
+    previewUrl: `${baseUrl}/preview/${draft.id}?watch=true`,
+    createdAt: draft.createdAt,
+  });
+}

--- a/app/api/drafts/route.ts
+++ b/app/api/drafts/route.ts
@@ -38,9 +38,8 @@ export async function POST(request: Request) {
   });
 
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL
-    || process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}`
-      : 'http://localhost:3000';
+    || (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null)
+    || 'http://localhost:3000';
 
   return Response.json({
     id: draft.id,

--- a/app/preview/[id]/page.tsx
+++ b/app/preview/[id]/page.tsx
@@ -1,0 +1,31 @@
+import { getArticleDraft } from '@/lib/db/queries';
+import { notFound } from 'next/navigation';
+import { PreviewClient } from '@/components/preview-client';
+
+export default async function PreviewPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const draft = await getArticleDraft({ id });
+
+  if (!draft || draft.status === 'discarded') {
+    notFound();
+  }
+
+  return (
+    <PreviewClient
+      initialDraft={{
+        id: draft.id,
+        title: draft.title,
+        content: draft.content,
+        description: draft.description,
+        status: draft.status,
+        createdAt: draft.createdAt.toISOString(),
+        updatedAt: draft.updatedAt.toISOString(),
+        intercomArticleId: draft.intercomArticleId,
+      }}
+    />
+  );
+}

--- a/components/api-keys-manager.tsx
+++ b/components/api-keys-manager.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { toast } from '@/components/toast';
+
+interface ApiKeyInfo {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  createdAt: string;
+  expiresAt: string | null;
+  lastUsedAt: string | null;
+  revokedAt: string | null;
+}
+
+export function ApiKeysManager() {
+  const [keys, setKeys] = useState<ApiKeyInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [newKeyName, setNewKeyName] = useState('');
+  const [createdKey, setCreatedKey] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  async function fetchKeys() {
+    try {
+      const res = await fetch('/api/api-keys');
+      if (res.ok) {
+        setKeys(await res.json());
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    fetchKeys();
+  }, []);
+
+  async function handleCreate() {
+    if (!newKeyName.trim()) return;
+    setCreating(true);
+    try {
+      const res = await fetch('/api/api-keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newKeyName.trim() }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setCreatedKey(data.key);
+        setNewKeyName('');
+        fetchKeys();
+      } else {
+        toast({ type: 'error', description: 'Failed to create API key' });
+      }
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleRevoke(id: string) {
+    const res = await fetch(`/api/api-keys?id=${id}`, { method: 'DELETE' });
+    if (res.ok) {
+      toast({ type: 'success', description: 'API key revoked' });
+      fetchKeys();
+    } else {
+      toast({ type: 'error', description: 'Failed to revoke API key' });
+    }
+  }
+
+  function copyToClipboard(text: string) {
+    navigator.clipboard.writeText(text);
+    toast({ type: 'success', description: 'Copied to clipboard' });
+  }
+
+  const activeKeys = keys.filter((k) => !k.revokedAt);
+  const revokedKeys = keys.filter((k) => k.revokedAt);
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Create new key */}
+      <div className="flex flex-col gap-3 p-4 border rounded-lg dark:border-zinc-700">
+        <h2 className="text-sm font-medium dark:text-zinc-200">
+          Create API Key
+        </h2>
+        <div className="flex gap-2">
+          <Input
+            placeholder="Key name (e.g. Claude Code)"
+            value={newKeyName}
+            onChange={(e) => setNewKeyName(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+          />
+          <Button
+            onClick={handleCreate}
+            disabled={creating || !newKeyName.trim()}
+          >
+            {creating ? 'Creating...' : 'Create'}
+          </Button>
+        </div>
+      </div>
+
+      {/* Show newly created key */}
+      {createdKey && (
+        <div className="p-4 border rounded-lg bg-green-50 dark:bg-green-950/20 border-green-200 dark:border-green-800">
+          <p className="text-sm font-medium text-green-800 dark:text-green-200 mb-2">
+            API key created. Copy it now — it won't be shown again.
+          </p>
+          <div className="flex gap-2 items-center">
+            <code className="flex-1 text-sm bg-white dark:bg-zinc-900 p-2 rounded border dark:border-zinc-700 font-mono break-all">
+              {createdKey}
+            </code>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => copyToClipboard(createdKey)}
+            >
+              Copy
+            </Button>
+          </div>
+          <button
+            type="button"
+            className="text-xs text-gray-500 mt-2 hover:underline"
+            onClick={() => setCreatedKey(null)}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {/* Active keys */}
+      <div className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium dark:text-zinc-200">
+          Active Keys
+        </h2>
+        {loading ? (
+          <p className="text-sm text-gray-400">Loading...</p>
+        ) : activeKeys.length === 0 ? (
+          <p className="text-sm text-gray-400">No active API keys</p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {activeKeys.map((key) => (
+              <div
+                key={key.id}
+                className="flex items-center justify-between p-3 border rounded-lg dark:border-zinc-700"
+              >
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-sm font-medium dark:text-zinc-200">
+                    {key.name}
+                  </span>
+                  <span className="text-xs text-gray-400 font-mono">
+                    {key.keyPrefix}...
+                  </span>
+                  <span className="text-xs text-gray-400">
+                    Created{' '}
+                    {new Date(key.createdAt).toLocaleDateString()}
+                    {key.lastUsedAt &&
+                      ` · Last used ${new Date(key.lastUsedAt).toLocaleDateString()}`}
+                  </span>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleRevoke(key.id)}
+                  className="text-red-600 hover:text-red-700 dark:text-red-400"
+                >
+                  Revoke
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Revoked keys */}
+      {revokedKeys.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <h2 className="text-sm font-medium text-gray-400">Revoked Keys</h2>
+          <div className="flex flex-col gap-2">
+            {revokedKeys.map((key) => (
+              <div
+                key={key.id}
+                className="flex items-center justify-between p-3 border rounded-lg opacity-50 dark:border-zinc-700"
+              >
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-sm font-medium dark:text-zinc-200">
+                    {key.name}
+                  </span>
+                  <span className="text-xs text-gray-400 font-mono">
+                    {key.keyPrefix}...
+                  </span>
+                  <span className="text-xs text-gray-400">
+                    Revoked{' '}
+                    {new Date(key.revokedAt!).toLocaleDateString()}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/api-keys-manager.tsx
+++ b/components/api-keys-manager.tsx
@@ -104,7 +104,7 @@ export function ApiKeysManager() {
       {createdKey && (
         <div className="p-4 border rounded-lg bg-green-50 dark:bg-green-950/20 border-green-200 dark:border-green-800">
           <p className="text-sm font-medium text-green-800 dark:text-green-200 mb-2">
-            API key created. Copy it now — it won't be shown again.
+            API key created. Copy it now — it won&apos;t be shown again.
           </p>
           <div className="flex gap-2 items-center">
             <code className="flex-1 text-sm bg-white dark:bg-zinc-900 p-2 rounded border dark:border-zinc-700 font-mono break-all">

--- a/components/intercom-upload-dialog.tsx
+++ b/components/intercom-upload-dialog.tsx
@@ -96,7 +96,7 @@ function generateDefaultDescription(title: string, content: string): string {
 
   // Ensure focus phrase appears early for SEO
   const hasFocus = focus && candidate.toLowerCase().includes(focus.toLowerCase());
-  let result = hasFocus ? candidate : `${focus ? focus + ': ' : ''}${candidate}`.trim();
+  let result = hasFocus ? candidate : `${focus ? `${focus}: ` : ''}${candidate}`.trim();
 
   // Use active-voice cues when missing verbs (simple heuristic)
   if (!/[a-zA-Z]+\s+(to|for|lets|helps|learn|set|create|manage|troubleshoot|optimize)/i.test(result)) {

--- a/components/preview-actions.tsx
+++ b/components/preview-actions.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { toast } from '@/components/toast';
+
+export function PreviewActions({
+  draftId,
+  status,
+}: {
+  draftId: string;
+  status: string;
+}) {
+  const [publishing, setPublishing] = useState(false);
+  const [discarding, setDiscarding] = useState(false);
+  const [currentStatus, setCurrentStatus] = useState(status);
+
+  async function handlePublish() {
+    setPublishing(true);
+    try {
+      const res = await fetch(`/api/drafts/${draftId}/publish`, {
+        method: 'POST',
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setCurrentStatus('published');
+        toast({
+          type: 'success',
+          description: 'Article published to Intercom!',
+        });
+        if (data.intercomUrl) {
+          window.open(data.intercomUrl, '_blank');
+        }
+      } else {
+        const err = await res.json().catch(() => ({}));
+        toast({
+          type: 'error',
+          description: err.error || 'Failed to publish',
+        });
+      }
+    } finally {
+      setPublishing(false);
+    }
+  }
+
+  async function handleDiscard() {
+    setDiscarding(true);
+    try {
+      const res = await fetch(`/api/drafts/${draftId}/discard`, {
+        method: 'POST',
+      });
+      if (res.ok) {
+        setCurrentStatus('discarded');
+        toast({ type: 'success', description: 'Draft discarded' });
+      }
+    } finally {
+      setDiscarding(false);
+    }
+  }
+
+  if (currentStatus === 'published') {
+    return (
+      <span className="text-sm text-green-600 dark:text-green-400">
+        Published to Intercom
+      </span>
+    );
+  }
+
+  if (currentStatus === 'discarded') {
+    return (
+      <span className="text-sm text-gray-400">Discarded</span>
+    );
+  }
+
+  return (
+    <div className="flex gap-2">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleDiscard}
+        disabled={discarding}
+        className="text-gray-500"
+      >
+        {discarding ? 'Discarding...' : 'Discard'}
+      </Button>
+      <Button
+        size="sm"
+        onClick={handlePublish}
+        disabled={publishing}
+      >
+        {publishing ? 'Publishing...' : 'Publish to Intercom'}
+      </Button>
+    </div>
+  );
+}

--- a/components/preview-client.tsx
+++ b/components/preview-client.tsx
@@ -4,6 +4,9 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/components/toast';
 import { CollectionSelectorModal } from '@/components/collection-selector-modal';
+import { EditorToolbar } from '@/components/editor-toolbar';
+import { Editor } from '@/components/text-editor';
+import type { EditorView } from 'prosemirror-view';
 import { Loader2, ChevronRight, Folder } from 'lucide-react';
 
 interface DraftData {
@@ -49,6 +52,7 @@ export function PreviewClient({
   const [saving, setSaving] = useState(false);
   const [renderedHtml, setRenderedHtml] = useState('');
   const lastUpdatedAt = useRef(draft.updatedAt);
+  const [editorView, setEditorView] = useState<EditorView | null>(null);
 
   // Publish dialog state
   const [publishDialogOpen, setPublishDialogOpen] = useState(false);
@@ -180,6 +184,7 @@ export function PreviewClient({
           updatedAt: updated.updatedAt,
         });
         lastUpdatedAt.current = updated.updatedAt;
+        setEditorView(null);
         setEditing(false);
         toast({ type: 'success', description: 'Saved' });
       } else {
@@ -260,6 +265,7 @@ export function PreviewClient({
   }
 
   function cancelEditing() {
+    setEditorView(null);
     setEditing(false);
   }
 
@@ -491,39 +497,39 @@ export function PreviewClient({
       {editing ? (
         <div className="max-w-3xl mx-auto px-6 py-8 flex flex-col gap-4">
           <div>
-            <label className="text-xs font-medium text-gray-500 dark:text-zinc-400 mb-1 block">
-              Title
-            </label>
             <input
               type="text"
               value={editTitle}
               onChange={(e) => setEditTitle(e.target.value)}
-              className="w-full text-2xl font-bold border-0 border-b border-gray-200 dark:border-zinc-700 bg-transparent px-0 py-2 focus:outline-none focus:border-blue-500 dark:text-zinc-50"
+              placeholder="Article title"
+              className="w-full text-3xl font-bold border-0 bg-transparent px-0 py-2 focus:outline-none dark:text-zinc-50 placeholder:text-gray-300 dark:placeholder:text-zinc-600"
             />
           </div>
           <div>
-            <label className="text-xs font-medium text-gray-500 dark:text-zinc-400 mb-1 block">
-              Description (optional, max 255 chars)
-            </label>
             <input
               type="text"
               value={editDescription}
               onChange={(e) =>
                 setEditDescription(e.target.value.slice(0, 255))
               }
-              placeholder="Short description for SEO"
-              className="w-full text-sm border-0 border-b border-gray-200 dark:border-zinc-700 bg-transparent px-0 py-2 focus:outline-none focus:border-blue-500 dark:text-zinc-300"
+              placeholder="Short description for SEO (optional, max 255 chars)"
+              className="w-full text-base border-0 bg-transparent px-0 py-1 focus:outline-none text-gray-500 dark:text-zinc-400 placeholder:text-gray-300 dark:placeholder:text-zinc-600"
             />
           </div>
-          <div>
-            <label className="text-xs font-medium text-gray-500 dark:text-zinc-400 mb-1 block">
-              Content (Markdown)
-            </label>
-            <textarea
-              value={editContent}
-              onChange={(e) => setEditContent(e.target.value)}
-              rows={30}
-              className="w-full font-mono text-sm border rounded-lg border-gray-200 dark:border-zinc-700 bg-gray-50 dark:bg-zinc-900 p-4 focus:outline-none focus:border-blue-500 dark:text-zinc-200 resize-y"
+          <div className="sticky top-[53px] z-10 bg-white/95 dark:bg-zinc-950/95 backdrop-blur-sm border-b border-gray-100 dark:border-zinc-800 -mx-6 px-6 py-2">
+            <EditorToolbar editorView={editorView} />
+          </div>
+          <div className="min-h-[400px]">
+            <Editor
+              content={editContent}
+              onSaveContent={(updatedContent) => {
+                setEditContent(updatedContent);
+              }}
+              status="idle"
+              isCurrentVersion={true}
+              currentVersionIndex={0}
+              suggestions={[]}
+              onEditorReady={(view) => setEditorView(view)}
             />
           </div>
         </div>

--- a/components/preview-client.tsx
+++ b/components/preview-client.tsx
@@ -1,0 +1,345 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { toast } from '@/components/toast';
+
+interface DraftData {
+  id: string;
+  title: string;
+  content: string;
+  description: string | null;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  intercomArticleId: string | null;
+}
+
+export function PreviewClient({
+  initialDraft,
+}: {
+  initialDraft: DraftData;
+}) {
+  const [draft, setDraft] = useState(initialDraft);
+  const [editing, setEditing] = useState(false);
+  const [editTitle, setEditTitle] = useState(draft.title);
+  const [editContent, setEditContent] = useState(draft.content);
+  const [editDescription, setEditDescription] = useState(
+    draft.description || '',
+  );
+  const [saving, setSaving] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [renderedHtml, setRenderedHtml] = useState('');
+  const lastUpdatedAt = useRef(draft.updatedAt);
+
+  // Render markdown to HTML client-side for preview
+  const renderMarkdown = useCallback(async (content: string) => {
+    // Simple markdown rendering - use the server for accurate rendering
+    // For now, do basic conversion
+    const lines = content.split('\n');
+    let html = '';
+    let inList = false;
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+
+      if (trimmed.startsWith('### ')) {
+        if (inList) { html += '</ul>'; inList = false; }
+        html += `<h3>${trimmed.slice(4)}</h3>`;
+      } else if (trimmed.startsWith('## ')) {
+        if (inList) { html += '</ul>'; inList = false; }
+        html += `<h2>${trimmed.slice(3)}</h2>`;
+      } else if (trimmed.startsWith('# ')) {
+        if (inList) { html += '</ul>'; inList = false; }
+        html += `<h1>${trimmed.slice(2)}</h1>`;
+      } else if (trimmed.startsWith('- ') || trimmed.startsWith('* ')) {
+        if (!inList) { html += '<ul>'; inList = true; }
+        html += `<li>${formatInline(trimmed.slice(2))}</li>`;
+      } else if (trimmed === '') {
+        if (inList) { html += '</ul>'; inList = false; }
+      } else {
+        if (inList) { html += '</ul>'; inList = false; }
+        html += `<p>${formatInline(trimmed)}</p>`;
+      }
+    }
+    if (inList) html += '</ul>';
+    return html;
+  }, []);
+
+  useEffect(() => {
+    renderMarkdown(draft.content).then(setRenderedHtml);
+  }, [draft.content, renderMarkdown]);
+
+  // Poll for changes only when the URL has ?watch=true (set by the skill)
+  // This avoids constant polling during normal browsing
+  const [watching, setWatching] = useState(false);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    setWatching(params.has('watch'));
+  }, []);
+
+  useEffect(() => {
+    if (!watching || draft.status !== 'draft' || editing) return;
+
+    const interval = setInterval(async () => {
+      try {
+        const res = await fetch(`/api/drafts/${draft.id}`);
+        if (!res.ok) return;
+        const updated: DraftData = await res.json();
+
+        if (updated.updatedAt !== lastUpdatedAt.current) {
+          lastUpdatedAt.current = updated.updatedAt;
+          setDraft(updated);
+          setEditTitle(updated.title);
+          setEditContent(updated.content);
+          setEditDescription(updated.description || '');
+        }
+      } catch {
+        // Silently ignore polling errors
+      }
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [draft.id, draft.status, editing, watching]);
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/drafts/${draft.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: editTitle,
+          content: editContent,
+          description: editDescription || null,
+        }),
+      });
+
+      if (res.ok) {
+        const updated = await res.json();
+        setDraft({
+          ...draft,
+          title: updated.title,
+          content: updated.content,
+          description: updated.description,
+          updatedAt: updated.updatedAt,
+        });
+        lastUpdatedAt.current = updated.updatedAt;
+        setEditing(false);
+        toast({ type: 'success', description: 'Saved' });
+      } else {
+        toast({ type: 'error', description: 'Failed to save' });
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handlePublish() {
+    setPublishing(true);
+    try {
+      const res = await fetch(`/api/drafts/${draft.id}/publish`, {
+        method: 'POST',
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setDraft({ ...draft, status: 'published' });
+        toast({
+          type: 'success',
+          description: 'Article published to Intercom!',
+        });
+        if (data.intercomUrl) {
+          window.open(data.intercomUrl, '_blank');
+        }
+      } else {
+        const err = await res.json().catch(() => ({}));
+        toast({
+          type: 'error',
+          description: err.error || 'Failed to publish',
+        });
+      }
+    } finally {
+      setPublishing(false);
+    }
+  }
+
+  async function handleDiscard() {
+    const res = await fetch(`/api/drafts/${draft.id}/discard`, {
+      method: 'POST',
+    });
+    if (res.ok) {
+      setDraft({ ...draft, status: 'discarded' });
+      toast({ type: 'success', description: 'Draft discarded' });
+    }
+  }
+
+  function startEditing() {
+    setEditTitle(draft.title);
+    setEditContent(draft.content);
+    setEditDescription(draft.description || '');
+    setEditing(true);
+  }
+
+  function cancelEditing() {
+    setEditing(false);
+  }
+
+  const isDraft = draft.status === 'draft';
+
+  return (
+    <div className="min-h-dvh bg-white dark:bg-zinc-950">
+      {/* Header bar */}
+      <div className="sticky top-0 z-10 border-b bg-white/80 backdrop-blur-sm dark:bg-zinc-950/80 dark:border-zinc-800">
+        <div className="max-w-3xl mx-auto px-6 py-3 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <span
+              className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                draft.status === 'published'
+                  ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                  : draft.status === 'discarded'
+                    ? 'bg-gray-100 text-gray-500 dark:bg-zinc-800 dark:text-zinc-500'
+                    : 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
+              }`}
+            >
+              {draft.status === 'published'
+                ? 'Published'
+                : draft.status === 'discarded'
+                  ? 'Discarded'
+                  : 'Draft'}
+            </span>
+            {editing && (
+              <span className="text-xs text-blue-500 font-medium">
+                Editing
+              </span>
+            )}
+          </div>
+          <div className="flex gap-2">
+            {isDraft && !editing && (
+              <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={startEditing}
+                >
+                  Edit
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleDiscard}
+                  className="text-gray-500"
+                >
+                  Discard
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={handlePublish}
+                  disabled={publishing}
+                >
+                  {publishing ? 'Publishing...' : 'Publish to Intercom'}
+                </Button>
+              </>
+            )}
+            {editing && (
+              <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={cancelEditing}
+                >
+                  Cancel
+                </Button>
+                <Button size="sm" onClick={handleSave} disabled={saving}>
+                  {saving ? 'Saving...' : 'Save'}
+                </Button>
+              </>
+            )}
+            {draft.status === 'published' && (
+              <span className="text-sm text-green-600 dark:text-green-400">
+                Published to Intercom
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      {editing ? (
+        <div className="max-w-3xl mx-auto px-6 py-8 flex flex-col gap-4">
+          <div>
+            <label className="text-xs font-medium text-gray-500 dark:text-zinc-400 mb-1 block">
+              Title
+            </label>
+            <input
+              type="text"
+              value={editTitle}
+              onChange={(e) => setEditTitle(e.target.value)}
+              className="w-full text-2xl font-bold border-0 border-b border-gray-200 dark:border-zinc-700 bg-transparent px-0 py-2 focus:outline-none focus:border-blue-500 dark:text-zinc-50"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-medium text-gray-500 dark:text-zinc-400 mb-1 block">
+              Description (optional, max 255 chars)
+            </label>
+            <input
+              type="text"
+              value={editDescription}
+              onChange={(e) =>
+                setEditDescription(e.target.value.slice(0, 255))
+              }
+              placeholder="Short description for SEO"
+              className="w-full text-sm border-0 border-b border-gray-200 dark:border-zinc-700 bg-transparent px-0 py-2 focus:outline-none focus:border-blue-500 dark:text-zinc-300"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-medium text-gray-500 dark:text-zinc-400 mb-1 block">
+              Content (Markdown)
+            </label>
+            <textarea
+              value={editContent}
+              onChange={(e) => setEditContent(e.target.value)}
+              rows={30}
+              className="w-full font-mono text-sm border rounded-lg border-gray-200 dark:border-zinc-700 bg-gray-50 dark:bg-zinc-900 p-4 focus:outline-none focus:border-blue-500 dark:text-zinc-200 resize-y"
+            />
+          </div>
+        </div>
+      ) : (
+        <article className="max-w-3xl mx-auto px-6 py-12">
+          <h1 className="text-3xl font-bold tracking-tight mb-4 dark:text-zinc-50">
+            {draft.title}
+          </h1>
+          {draft.description && (
+            <p className="text-lg text-gray-500 dark:text-zinc-400 mb-8">
+              {draft.description}
+            </p>
+          )}
+          <div
+            className="prose prose-gray dark:prose-invert max-w-none
+              prose-headings:font-semibold
+              prose-h2:text-xl prose-h2:mt-8 prose-h2:mb-3
+              prose-h3:text-lg prose-h3:mt-6 prose-h3:mb-2
+              prose-p:leading-7
+              prose-li:leading-7
+              prose-a:text-blue-600 dark:prose-a:text-blue-400
+              prose-code:text-sm prose-code:bg-gray-100 dark:prose-code:bg-zinc-800 prose-code:px-1 prose-code:py-0.5 prose-code:rounded
+              prose-pre:bg-gray-50 dark:prose-pre:bg-zinc-900"
+            dangerouslySetInnerHTML={{ __html: renderedHtml }}
+          />
+        </article>
+      )}
+    </div>
+  );
+}
+
+/** Simple inline markdown formatting */
+function formatInline(text: string): string {
+  return text
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.+?)\*/g, '<em>$1</em>')
+    .replace(/`(.+?)`/g, '<code>$1</code>')
+    .replace(
+      /\[(.+?)\]\((.+?)\)/g,
+      '<a href="$2">$1</a>',
+    );
+}

--- a/components/preview-client.tsx
+++ b/components/preview-client.tsx
@@ -225,7 +225,7 @@ export function PreviewClient({
         setPublishDialogOpen(false);
         toast({
           type: 'success',
-          description: 'Article published to Intercom!',
+          description: 'Draft saved to Intercom!',
         });
         if (data.intercomUrl) {
           window.open(data.intercomUrl, '_blank');
@@ -234,7 +234,7 @@ export function PreviewClient({
         const err = await res.json().catch(() => ({}));
         toast({
           type: 'error',
-          description: err.error || 'Failed to publish',
+          description: err.error || 'Failed to save to Intercom',
         });
       }
     } finally {
@@ -281,7 +281,7 @@ export function PreviewClient({
               }`}
             >
               {draft.status === 'published'
-                ? 'Published'
+                ? 'Saved to Intercom'
                 : draft.status === 'discarded'
                   ? 'Discarded'
                   : 'Draft'}
@@ -314,7 +314,7 @@ export function PreviewClient({
                   size="sm"
                   onClick={openPublishDialog}
                 >
-                  Publish to Intercom
+                  Save draft to Intercom
                 </Button>
               </>
             )}
@@ -334,7 +334,7 @@ export function PreviewClient({
             )}
             {draft.status === 'published' && (
               <span className="text-sm text-green-600 dark:text-green-400">
-                Published to Intercom
+                Saved to Intercom
               </span>
             )}
           </div>
@@ -351,7 +351,7 @@ export function PreviewClient({
           <div className="relative bg-white dark:bg-zinc-900 rounded-xl shadow-xl w-full max-w-md mx-4 p-6 space-y-5">
             <div className="flex items-center justify-between">
               <h2 className="text-lg font-semibold dark:text-zinc-50">
-                Publish to Intercom
+                Save draft to Intercom
               </h2>
               <button
                 onClick={() => setPublishDialogOpen(false)}
@@ -466,10 +466,10 @@ export function PreviewClient({
                 {publishing ? (
                   <>
                     <Loader2 className="size-4 animate-spin mr-2" />
-                    Publishing...
+                    Saving...
                   </>
                 ) : (
-                  'Publish'
+                  'Save to Intercom'
                 )}
               </Button>
             </div>

--- a/components/preview-client.tsx
+++ b/components/preview-client.tsx
@@ -101,18 +101,36 @@ export function PreviewClient({
     renderMarkdown(draft.content).then(setRenderedHtml);
   }, [draft.content, renderMarkdown]);
 
-  // Poll for changes only when the URL has ?watch=true
+  // Poll for changes only when ?watch=true, tab is visible, and within timeout
   const [watching, setWatching] = useState(false);
+  const [tabVisible, setTabVisible] = useState(true);
+  const watchStarted = useRef<number>(0);
+  const WATCH_TIMEOUT_MS = 10 * 60 * 1000; // Stop polling after 10 minutes
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    setWatching(params.has('watch'));
+    if (params.has('watch')) {
+      setWatching(true);
+      watchStarted.current = Date.now();
+    }
   }, []);
 
   useEffect(() => {
-    if (!watching || draft.status !== 'draft' || editing) return;
+    const handleVisibility = () => setTabVisible(!document.hidden);
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, []);
+
+  useEffect(() => {
+    if (!watching || !tabVisible || draft.status !== 'draft' || editing) return;
 
     const interval = setInterval(async () => {
+      // Auto-stop after timeout
+      if (Date.now() - watchStarted.current > WATCH_TIMEOUT_MS) {
+        setWatching(false);
+        return;
+      }
+
       try {
         const res = await fetch(`/api/drafts/${draft.id}`);
         if (!res.ok) return;
@@ -131,7 +149,7 @@ export function PreviewClient({
     }, 5000);
 
     return () => clearInterval(interval);
-  }, [draft.id, draft.status, editing, watching]);
+  }, [draft.id, draft.status, editing, watching, tabVisible]);
 
   // Load admins when publish dialog opens
   useEffect(() => {

--- a/components/preview-client.tsx
+++ b/components/preview-client.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/components/toast';
+import { CollectionSelectorModal } from '@/components/collection-selector-modal';
+import { Loader2, ChevronRight, Folder } from 'lucide-react';
 
 interface DraftData {
   id: string;
@@ -14,6 +16,23 @@ interface DraftData {
   updatedAt: string;
   intercomArticleId: string | null;
 }
+
+interface IntercomAdmin {
+  id: string;
+  name: string;
+  email: string;
+}
+
+interface Collection {
+  id: string;
+  name: string;
+  description?: string;
+  parent_id: string | null;
+  children: Collection[];
+}
+
+// Session cache for admins (avoids re-fetching on every dialog open)
+let adminsCache: IntercomAdmin[] | null = null;
 
 export function PreviewClient({
   initialDraft,
@@ -28,14 +47,22 @@ export function PreviewClient({
     draft.description || '',
   );
   const [saving, setSaving] = useState(false);
-  const [publishing, setPublishing] = useState(false);
   const [renderedHtml, setRenderedHtml] = useState('');
   const lastUpdatedAt = useRef(draft.updatedAt);
 
+  // Publish dialog state
+  const [publishDialogOpen, setPublishDialogOpen] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [collectionModalOpen, setCollectionModalOpen] = useState(false);
+  const [selectedCollection, setSelectedCollection] = useState<Collection | null>(null);
+  const [collectionPath, setCollectionPath] = useState<Collection[]>([]);
+  const [selectedAuthor, setSelectedAuthor] = useState<string>('');
+  const [admins, setAdmins] = useState<IntercomAdmin[]>([]);
+  const [isLoadingAdmins, setIsLoadingAdmins] = useState(false);
+  const [publishDescription, setPublishDescription] = useState('');
+
   // Render markdown to HTML client-side for preview
   const renderMarkdown = useCallback(async (content: string) => {
-    // Simple markdown rendering - use the server for accurate rendering
-    // For now, do basic conversion
     const lines = content.split('\n');
     let html = '';
     let inList = false;
@@ -70,8 +97,7 @@ export function PreviewClient({
     renderMarkdown(draft.content).then(setRenderedHtml);
   }, [draft.content, renderMarkdown]);
 
-  // Poll for changes only when the URL has ?watch=true (set by the skill)
-  // This avoids constant polling during normal browsing
+  // Poll for changes only when the URL has ?watch=true
   const [watching, setWatching] = useState(false);
 
   useEffect(() => {
@@ -102,6 +128,34 @@ export function PreviewClient({
 
     return () => clearInterval(interval);
   }, [draft.id, draft.status, editing, watching]);
+
+  // Load admins when publish dialog opens
+  useEffect(() => {
+    if (!publishDialogOpen) return;
+
+    // Pre-fill description from draft
+    setPublishDescription(draft.description || '');
+
+    if (adminsCache) {
+      setAdmins(adminsCache);
+      return;
+    }
+
+    setIsLoadingAdmins(true);
+    fetch('/api/intercom/admins')
+      .then(async (res) => {
+        if (res.ok) {
+          const data = await res.json();
+          const fetched = data.admins || [];
+          adminsCache = fetched;
+          setAdmins(fetched);
+        }
+      })
+      .catch(() => {
+        toast({ type: 'error', description: 'Failed to load authors' });
+      })
+      .finally(() => setIsLoadingAdmins(false));
+  }, [publishDialogOpen, draft.description]);
 
   async function handleSave() {
     setSaving(true);
@@ -136,15 +190,39 @@ export function PreviewClient({
     }
   }
 
+  function openPublishDialog() {
+    setSelectedCollection(null);
+    setCollectionPath([]);
+    setSelectedAuthor('');
+    setPublishDescription(draft.description || '');
+    setPublishDialogOpen(true);
+  }
+
   async function handlePublish() {
+    if (!selectedCollection) {
+      toast({ type: 'error', description: 'Please select a collection' });
+      return;
+    }
+    if (!selectedAuthor) {
+      toast({ type: 'error', description: 'Please select an author' });
+      return;
+    }
+
     setPublishing(true);
     try {
       const res = await fetch(`/api/drafts/${draft.id}/publish`, {
         method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          collectionId: selectedCollection.id,
+          authorId: selectedAuthor,
+          description: publishDescription || undefined,
+        }),
       });
       if (res.ok) {
         const data = await res.json();
         setDraft({ ...draft, status: 'published' });
+        setPublishDialogOpen(false);
         toast({
           type: 'success',
           description: 'Article published to Intercom!',
@@ -234,10 +312,9 @@ export function PreviewClient({
                 </Button>
                 <Button
                   size="sm"
-                  onClick={handlePublish}
-                  disabled={publishing}
+                  onClick={openPublishDialog}
                 >
-                  {publishing ? 'Publishing...' : 'Publish to Intercom'}
+                  Publish to Intercom
                 </Button>
               </>
             )}
@@ -263,6 +340,152 @@ export function PreviewClient({
           </div>
         </div>
       </div>
+
+      {/* Publish dialog */}
+      {publishDialogOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setPublishDialogOpen(false)}
+          />
+          <div className="relative bg-white dark:bg-zinc-900 rounded-xl shadow-xl w-full max-w-md mx-4 p-6 space-y-5">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold dark:text-zinc-50">
+                Publish to Intercom
+              </h2>
+              <button
+                onClick={() => setPublishDialogOpen(false)}
+                className="text-gray-400 hover:text-gray-600 dark:hover:text-zinc-300"
+              >
+                &times;
+              </button>
+            </div>
+
+            {/* Collection selector */}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-gray-700 dark:text-zinc-300">
+                Collection
+              </label>
+              <button
+                type="button"
+                onClick={() => setCollectionModalOpen(true)}
+                className="w-full flex items-center gap-3 p-3 border rounded-lg text-left hover:bg-gray-50 dark:hover:bg-zinc-800 dark:border-zinc-700 transition-colors"
+              >
+                <Folder className="size-4 text-gray-400 shrink-0" />
+                {selectedCollection ? (
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium text-sm dark:text-zinc-100 truncate">
+                      {selectedCollection.name}
+                    </p>
+                    {collectionPath.length > 0 && (
+                      <p className="text-xs text-gray-500 dark:text-zinc-400 flex items-center gap-0.5 truncate">
+                        {collectionPath.map((c, i) => (
+                          <span key={c.id} className="flex items-center gap-0.5">
+                            {i > 0 && <ChevronRight className="size-3" />}
+                            {c.name}
+                          </span>
+                        ))}
+                      </p>
+                    )}
+                  </div>
+                ) : (
+                  <span className="text-sm text-gray-400 dark:text-zinc-500">
+                    Select collection...
+                  </span>
+                )}
+              </button>
+            </div>
+
+            {/* Description */}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-gray-700 dark:text-zinc-300">
+                Description (optional)
+              </label>
+              <textarea
+                value={publishDescription}
+                onChange={(e) =>
+                  setPublishDescription(e.target.value.slice(0, 255))
+                }
+                placeholder="SEO-friendly summary (up to 255 characters)"
+                rows={3}
+                className="w-full text-sm border rounded-lg p-3 dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-200 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+              />
+              <p className="text-xs text-gray-400 text-right">
+                {publishDescription.length}/255
+              </p>
+            </div>
+
+            {/* Author selector */}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-gray-700 dark:text-zinc-300">
+                Author
+              </label>
+              {isLoadingAdmins ? (
+                <div className="flex items-center gap-2 py-2">
+                  <Loader2 className="size-4 animate-spin text-gray-400" />
+                  <span className="text-sm text-gray-400">Loading authors...</span>
+                </div>
+              ) : admins.length === 0 ? (
+                <p className="text-sm text-red-500">
+                  No admins found. Check Intercom configuration.
+                </p>
+              ) : (
+                <select
+                  value={selectedAuthor}
+                  onChange={(e) => setSelectedAuthor(e.target.value)}
+                  className="w-full text-sm border rounded-lg p-2.5 dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-200 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  <option value="">Select author...</option>
+                  {admins.map((admin) => (
+                    <option key={admin.id} value={admin.id}>
+                      {admin.name}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
+
+            {/* Actions */}
+            <div className="flex gap-3 pt-2">
+              <Button
+                variant="outline"
+                className="flex-1"
+                onClick={() => setPublishDialogOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                className="flex-1"
+                onClick={handlePublish}
+                disabled={
+                  publishing ||
+                  !selectedCollection ||
+                  !selectedAuthor
+                }
+              >
+                {publishing ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin mr-2" />
+                    Publishing...
+                  </>
+                ) : (
+                  'Publish'
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Collection selector modal (reused from main app) */}
+      <CollectionSelectorModal
+        isOpen={collectionModalOpen}
+        onClose={() => setCollectionModalOpen(false)}
+        onSelect={(collection, path) => {
+          setSelectedCollection(collection);
+          setCollectionPath(path);
+        }}
+      />
 
       {/* Content */}
       {editing ? (

--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronUp } from 'lucide-react';
 import Image from 'next/image';
+import Link from 'next/link';
 import type { User } from 'next-auth';
 import { signOut, useSession } from 'next-auth/react';
 import { useTheme } from 'next-themes';
@@ -74,6 +75,11 @@ export function SidebarUserNav({ user }: { user: User }) {
               }
             >
               {`Toggle ${resolvedTheme === 'light' ? 'dark' : 'light'} mode`}
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link href="/settings" className="cursor-pointer">
+                API Keys
+              </Link>
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild data-testid="user-nav-item-auth">

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -11,7 +11,7 @@ export function register() {
       globalThis.localStorage.getItem('__test');
     } catch {
       // @ts-ignore
-      delete globalThis.localStorage;
+      globalThis.localStorage = undefined;
     }
   }
 }

--- a/lib/api-key.ts
+++ b/lib/api-key.ts
@@ -1,29 +1,20 @@
-import { NextResponse } from 'next/server';
+import crypto from 'node:crypto';
 
-/**
- * Verify the DOCS_API_KEY header for programmatic access to publish endpoints.
- * Returns null if valid, or a NextResponse 401 if invalid.
- */
-export function verifyApiKey(
-  request: Request,
-): NextResponse | null {
-  const apiKey = process.env.DOCS_API_KEY;
-  if (!apiKey) return null; // API key auth not configured, skip
+const API_KEY_PREFIX = 'sk_';
+const RANDOM_LENGTH = 45;
 
-  const providedKey = request.headers.get('x-api-key');
-  if (providedKey === apiKey) return null; // Valid key
-
-  return null; // Don't reject — let the caller fall through to session auth
+/** Generate a cryptographically random API key */
+export function generateApiKey(): string {
+  const randomBytes = crypto.randomBytes(32);
+  return API_KEY_PREFIX + randomBytes.toString('base64url').slice(0, RANDOM_LENGTH);
 }
 
-/**
- * Check if request has a valid API key.
- * Returns true if DOCS_API_KEY is set and the request provides a matching x-api-key header.
- */
-export function hasValidApiKey(request: Request): boolean {
-  const apiKey = process.env.DOCS_API_KEY;
-  if (!apiKey) return false;
+/** Hash an API key with SHA-256 for storage */
+export function hashApiKey(key: string): string {
+  return crypto.createHash('sha256').update(key).digest('hex');
+}
 
-  const providedKey = request.headers.get('x-api-key');
-  return providedKey === apiKey;
+/** Extract prefix for display purposes */
+export function getKeyPrefix(key: string): string {
+  return key.slice(0, 8);
 }

--- a/lib/auth-helpers.ts
+++ b/lib/auth-helpers.ts
@@ -1,0 +1,28 @@
+import 'server-only';
+
+import { auth } from '@/app/(auth)/auth';
+import { headers } from 'next/headers';
+
+/**
+ * Get the authenticated user ID from either NextAuth session or API key.
+ * The API key user ID is injected by middleware via x-api-key-user-id header.
+ */
+export async function getAuthenticatedUser(): Promise<{
+  userId: string;
+  authMethod: 'session' | 'api-key';
+} | null> {
+  // Check for API key auth (set by middleware)
+  const headerStore = await headers();
+  const apiKeyUserId = headerStore.get('x-api-key-user-id');
+  if (apiKeyUserId) {
+    return { userId: apiKeyUserId, authMethod: 'api-key' };
+  }
+
+  // Fall back to NextAuth session
+  const session = await auth();
+  if (session?.user?.id) {
+    return { userId: session.user.id, authMethod: 'session' };
+  }
+
+  return null;
+}

--- a/lib/db/middleware-queries.ts
+++ b/lib/db/middleware-queries.ts
@@ -1,0 +1,17 @@
+import { sql } from '@vercel/postgres';
+
+export async function validateApiKeyFromDb(keyHash: string) {
+  try {
+    const { rows } = await sql`
+      SELECT "id", "userId" FROM "ApiKey"
+      WHERE "keyHash" = ${keyHash}
+        AND "revokedAt" IS NULL
+        AND ("expiresAt" IS NULL OR "expiresAt" > NOW())
+      LIMIT 1
+    `;
+    return rows[0] ? { id: rows[0].id, userId: rows[0].userId } : null;
+  } catch (error) {
+    console.error('[middleware-queries] validateApiKeyFromDb error:', error);
+    return null;
+  }
+}

--- a/lib/db/migrations/0010_api_keys.sql
+++ b/lib/db/migrations/0010_api_keys.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS "ApiKey" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "userId" uuid NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "name" varchar(255) NOT NULL,
+  "keyHash" varchar(64) NOT NULL,
+  "keyPrefix" varchar(8) NOT NULL,
+  "createdAt" timestamp DEFAULT now() NOT NULL,
+  "expiresAt" timestamp,
+  "lastUsedAt" timestamp,
+  "revokedAt" timestamp
+);
+
+CREATE INDEX IF NOT EXISTS "ApiKey_keyHash_idx" ON "ApiKey" ("keyHash");
+CREATE INDEX IF NOT EXISTS "ApiKey_userId_idx" ON "ApiKey" ("userId");

--- a/lib/db/migrations/0011_article_drafts.sql
+++ b/lib/db/migrations/0011_article_drafts.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS "ArticleDraft" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "userId" uuid NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "title" text NOT NULL,
+  "content" text NOT NULL,
+  "description" varchar(255),
+  "status" varchar DEFAULT 'draft' NOT NULL,
+  "intercomArticleId" varchar(255),
+  "createdAt" timestamp DEFAULT now() NOT NULL,
+  "updatedAt" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "ArticleDraft_userId_idx" ON "ArticleDraft" ("userId");
+CREATE INDEX IF NOT EXISTS "ArticleDraft_status_idx" ON "ArticleDraft" ("status");

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -71,6 +71,20 @@
       "when": 1741500000000,
       "tag": "0009_google_oauth",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1741600000000,
+      "tag": "0010_api_keys",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1741700000000,
+      "tag": "0011_article_drafts",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -9,7 +9,9 @@ import {
   gt,
   gte,
   inArray,
+  isNull,
   lt,
+  or,
   type SQL,
 } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/postgres-js';
@@ -27,6 +29,8 @@ import {
   type DBMessage,
   type Chat,
   stream,
+  apiKey,
+  articleDraft,
 } from './schema';
 import type { ArtifactKind } from '@/components/artifact';
 import type { VisibilityType } from '@/components/visibility-selector';
@@ -541,6 +545,193 @@ export async function getStreamIdsByChatId({ chatId }: { chatId: string }) {
     throw new ChatSDKError(
       'bad_request:database',
       'Failed to get stream ids by chat id',
+    );
+  }
+}
+
+// API Key functions
+
+export async function createApiKeyRecord({
+  userId,
+  name,
+  keyHash,
+  keyPrefix,
+  expiresAt,
+}: {
+  userId: string;
+  name: string;
+  keyHash: string;
+  keyPrefix: string;
+  expiresAt?: Date | null;
+}) {
+  try {
+    const [result] = await db
+      .insert(apiKey)
+      .values({ userId, name, keyHash, keyPrefix, expiresAt })
+      .returning();
+    return result;
+  } catch (error) {
+    throw new ChatSDKError('bad_request:database', 'Failed to create API key');
+  }
+}
+
+export async function getApiKeyByHash({ keyHash }: { keyHash: string }) {
+  try {
+    const [result] = await db
+      .select()
+      .from(apiKey)
+      .where(
+        and(
+          eq(apiKey.keyHash, keyHash),
+          isNull(apiKey.revokedAt),
+          or(isNull(apiKey.expiresAt), gt(apiKey.expiresAt, new Date())),
+        ),
+      );
+    return result ?? null;
+  } catch (error) {
+    throw new ChatSDKError(
+      'bad_request:database',
+      'Failed to validate API key',
+    );
+  }
+}
+
+export async function getApiKeysByUserId({ userId }: { userId: string }) {
+  try {
+    return await db
+      .select()
+      .from(apiKey)
+      .where(eq(apiKey.userId, userId))
+      .orderBy(desc(apiKey.createdAt));
+  } catch (error) {
+    throw new ChatSDKError(
+      'bad_request:database',
+      'Failed to get API keys',
+    );
+  }
+}
+
+export async function revokeApiKey({
+  id,
+  userId,
+}: {
+  id: string;
+  userId: string;
+}) {
+  try {
+    const [result] = await db
+      .update(apiKey)
+      .set({ revokedAt: new Date() })
+      .where(and(eq(apiKey.id, id), eq(apiKey.userId, userId)))
+      .returning();
+    return result;
+  } catch (error) {
+    throw new ChatSDKError('bad_request:database', 'Failed to revoke API key');
+  }
+}
+
+export async function updateApiKeyLastUsed({ id }: { id: string }) {
+  try {
+    await db
+      .update(apiKey)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(apiKey.id, id));
+  } catch {
+    // Fire-and-forget, don't throw
+  }
+}
+
+// Article Draft functions
+
+export async function createArticleDraft({
+  userId,
+  title,
+  content,
+  description,
+}: {
+  userId: string;
+  title: string;
+  content: string;
+  description?: string;
+}) {
+  try {
+    const [result] = await db
+      .insert(articleDraft)
+      .values({ userId, title, content, description })
+      .returning();
+    return result;
+  } catch (error) {
+    throw new ChatSDKError(
+      'bad_request:database',
+      'Failed to create article draft',
+    );
+  }
+}
+
+export async function getArticleDraft({ id }: { id: string }) {
+  try {
+    const [result] = await db
+      .select()
+      .from(articleDraft)
+      .where(eq(articleDraft.id, id));
+    return result ?? null;
+  } catch (error) {
+    throw new ChatSDKError(
+      'bad_request:database',
+      'Failed to get article draft',
+    );
+  }
+}
+
+export async function getArticleDraftsByUserId({ userId }: { userId: string }) {
+  try {
+    return await db
+      .select()
+      .from(articleDraft)
+      .where(eq(articleDraft.userId, userId))
+      .orderBy(desc(articleDraft.createdAt));
+  } catch (error) {
+    throw new ChatSDKError(
+      'bad_request:database',
+      'Failed to get article drafts',
+    );
+  }
+}
+
+export async function updateArticleDraft({
+  id,
+  title,
+  content,
+  description,
+  status,
+  intercomArticleId,
+}: {
+  id: string;
+  title?: string;
+  content?: string;
+  description?: string;
+  status?: 'draft' | 'published' | 'discarded';
+  intercomArticleId?: string;
+}) {
+  try {
+    const updates: Record<string, unknown> = { updatedAt: new Date() };
+    if (title !== undefined) updates.title = title;
+    if (content !== undefined) updates.content = content;
+    if (description !== undefined) updates.description = description;
+    if (status !== undefined) updates.status = status;
+    if (intercomArticleId !== undefined)
+      updates.intercomArticleId = intercomArticleId;
+
+    const [result] = await db
+      .update(articleDraft)
+      .set(updates)
+      .where(eq(articleDraft.id, id))
+      .returning();
+    return result;
+  } catch (error) {
+    throw new ChatSDKError(
+      'bad_request:database',
+      'Failed to update article draft',
     );
   }
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -157,3 +157,37 @@ export const stream = pgTable(
 );
 
 export type Stream = InferSelectModel<typeof stream>;
+
+export const apiKey = pgTable('ApiKey', {
+  id: uuid('id').primaryKey().notNull().defaultRandom(),
+  userId: uuid('userId')
+    .notNull()
+    .references(() => user.id, { onDelete: 'cascade' }),
+  name: varchar('name', { length: 255 }).notNull(),
+  keyHash: varchar('keyHash', { length: 64 }).notNull(),
+  keyPrefix: varchar('keyPrefix', { length: 8 }).notNull(),
+  createdAt: timestamp('createdAt').notNull().defaultNow(),
+  expiresAt: timestamp('expiresAt'),
+  lastUsedAt: timestamp('lastUsedAt'),
+  revokedAt: timestamp('revokedAt'),
+});
+
+export type ApiKey = InferSelectModel<typeof apiKey>;
+
+export const articleDraft = pgTable('ArticleDraft', {
+  id: uuid('id').primaryKey().notNull().defaultRandom(),
+  userId: uuid('userId')
+    .notNull()
+    .references(() => user.id, { onDelete: 'cascade' }),
+  title: text('title').notNull(),
+  content: text('content').notNull(),
+  description: varchar('description', { length: 255 }),
+  status: varchar('status', { enum: ['draft', 'published', 'discarded'] })
+    .notNull()
+    .default('draft'),
+  intercomArticleId: varchar('intercomArticleId', { length: 255 }),
+  createdAt: timestamp('createdAt').notNull().defaultNow(),
+  updatedAt: timestamp('updatedAt').notNull().defaultNow(),
+});
+
+export type ArticleDraft = InferSelectModel<typeof articleDraft>;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,15 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 import { isDevelopmentEnvironment } from './lib/constants';
+import { validateApiKeyFromDb } from './lib/db/middleware-queries';
+
+async function hashApiKeyInMiddleware(key: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(key);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+}
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -18,27 +27,59 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Get the NextAuth token to check if user has an active session
+  // Check NextAuth JWT token first
   const token = await getToken({
     req: request,
     secret: process.env.AUTH_SECRET,
     secureCookie: !isDevelopmentEnvironment,
   });
 
-  if (!token) {
-    // Allow the login page for unauthenticated users
+  if (token) {
     if (pathname === '/login') {
-      return NextResponse.next();
+      return NextResponse.redirect(new URL('/', request.url));
     }
-    return NextResponse.redirect(new URL('/login', request.url));
+    return NextResponse.next();
   }
 
-  // Redirect authenticated users away from login
-  if (token && pathname === '/login') {
-    return NextResponse.redirect(new URL('/', request.url));
+  // No JWT session. For API routes, try API key authentication.
+  if (pathname.startsWith('/api/')) {
+    const authHeader = request.headers.get('Authorization');
+    if (authHeader?.startsWith('Bearer ')) {
+      const apiKeyPlaintext = authHeader.slice(7);
+      const keyHash = await hashApiKeyInMiddleware(apiKeyPlaintext);
+
+      const apiKeyRecord = await validateApiKeyFromDb(keyHash);
+      if (apiKeyRecord) {
+        // Pass user identity to route handlers via headers.
+        // Safe: Next.js middleware rewrites headers before they reach handlers.
+        const requestHeaders = new Headers(request.headers);
+        requestHeaders.set('x-api-key-user-id', apiKeyRecord.userId);
+        requestHeaders.set('x-api-key-id', apiKeyRecord.id);
+
+        return NextResponse.next({
+          request: { headers: requestHeaders },
+        });
+      }
+
+      return new Response(JSON.stringify({ error: 'Invalid API key' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // No auth at all on API routes
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
 
-  return NextResponse.next();
+  // Allow the login page for unauthenticated users
+  if (pathname === '/login') {
+    return NextResponse.next();
+  }
+
+  return NextResponse.redirect(new URL('/login', request.url));
 }
 
 export const config = {

--- a/tests/helpers-api.ts
+++ b/tests/helpers-api.ts
@@ -1,0 +1,137 @@
+import { type APIRequestContext, request as playwrightRequest } from '@playwright/test';
+import crypto from 'node:crypto';
+
+const baseURL = `http://localhost:${process.env.PORT || 3000}`;
+
+/**
+ * Creates a test user directly in the database and generates an API key.
+ * Returns the API key plaintext for use in Authorization headers.
+ *
+ * This bypasses Google OAuth entirely, which is exactly what we need
+ * for testing API key authentication end-to-end.
+ */
+export async function createTestUserWithApiKey(opts: {
+  name: string;
+  request: APIRequestContext;
+}): Promise<{
+  userId: string;
+  apiKey: string;
+  keyId: string;
+}> {
+  // We use a raw SQL endpoint isn't available, so we seed directly
+  // via the postgres client. Import dynamically to avoid 'server-only' issues.
+  const postgres = (await import('postgres')).default;
+  const sql = postgres(process.env.POSTGRES_URL!);
+
+  try {
+    const email = `test-${opts.name}-${Date.now()}@test.playwright.io`;
+
+    // 1. Create user directly in DB
+    const [dbUser] = await sql`
+      INSERT INTO "User" ("email", "name")
+      VALUES (${email}, ${opts.name})
+      RETURNING "id"
+    `;
+
+    const userId = dbUser.id;
+
+    // 2. Generate an API key
+    const randomBytes = crypto.randomBytes(32);
+    const plainKey = `sk_${randomBytes.toString('base64url').slice(0, 45)}`;
+    const keyHash = crypto.createHash('sha256').update(plainKey).digest('hex');
+    const keyPrefix = plainKey.slice(0, 8);
+
+    // 3. Store hashed key in DB
+    const [keyRecord] = await sql`
+      INSERT INTO "ApiKey" ("userId", "name", "keyHash", "keyPrefix")
+      VALUES (${userId}, ${'test-key'}, ${keyHash}, ${keyPrefix})
+      RETURNING "id"
+    `;
+
+    return {
+      userId,
+      apiKey: plainKey,
+      keyId: keyRecord.id,
+    };
+  } finally {
+    await sql.end();
+  }
+}
+
+/**
+ * Creates an API request context with an API key in the Authorization header.
+ */
+export async function createApiContext(apiKey: string): Promise<APIRequestContext> {
+  return playwrightRequest.newContext({
+    baseURL,
+    extraHTTPHeaders: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+/**
+ * Creates a revoked API key for a user (for testing revoked key rejection).
+ */
+export async function createRevokedApiKey(userId: string): Promise<string> {
+  const postgres = (await import('postgres')).default;
+  const sql = postgres(process.env.POSTGRES_URL!);
+
+  try {
+    const randomBytes = crypto.randomBytes(32);
+    const plainKey = `sk_${randomBytes.toString('base64url').slice(0, 45)}`;
+    const keyHash = crypto.createHash('sha256').update(plainKey).digest('hex');
+    const keyPrefix = plainKey.slice(0, 8);
+
+    await sql`
+      INSERT INTO "ApiKey" ("userId", "name", "keyHash", "keyPrefix", "revokedAt")
+      VALUES (${userId}, ${'revoked-test-key'}, ${keyHash}, ${keyPrefix}, NOW())
+    `;
+
+    return plainKey;
+  } finally {
+    await sql.end();
+  }
+}
+
+/**
+ * Creates an expired API key for a user (for testing expired key rejection).
+ */
+export async function createExpiredApiKey(userId: string): Promise<string> {
+  const postgres = (await import('postgres')).default;
+  const sql = postgres(process.env.POSTGRES_URL!);
+
+  try {
+    const randomBytes = crypto.randomBytes(32);
+    const plainKey = `sk_${randomBytes.toString('base64url').slice(0, 45)}`;
+    const keyHash = crypto.createHash('sha256').update(plainKey).digest('hex');
+    const keyPrefix = plainKey.slice(0, 8);
+
+    await sql`
+      INSERT INTO "ApiKey" ("userId", "name", "keyHash", "keyPrefix", "expiresAt")
+      VALUES (${userId}, ${'expired-test-key'}, ${keyHash}, ${keyPrefix}, NOW() - INTERVAL '1 day')
+    `;
+
+    return plainKey;
+  } finally {
+    await sql.end();
+  }
+}
+
+/**
+ * Cleans up test data created during tests.
+ */
+export async function cleanupTestUser(userId: string): Promise<void> {
+  const postgres = (await import('postgres')).default;
+  const sql = postgres(process.env.POSTGRES_URL!);
+
+  try {
+    // Cascade deletes handle ApiKey and ArticleDraft via FK
+    await sql`DELETE FROM "ApiKey" WHERE "userId" = ${userId}`;
+    await sql`DELETE FROM "ArticleDraft" WHERE "userId" = ${userId}`;
+    await sql`DELETE FROM "User" WHERE "id" = ${userId}`;
+  } finally {
+    await sql.end();
+  }
+}

--- a/tests/routes/api-key-auth.test.ts
+++ b/tests/routes/api-key-auth.test.ts
@@ -1,0 +1,200 @@
+import { expect, test } from '@playwright/test';
+import { request as playwrightRequest } from '@playwright/test';
+import {
+  createTestUserWithApiKey,
+  createApiContext,
+  createRevokedApiKey,
+  createExpiredApiKey,
+  cleanupTestUser,
+} from '../helpers-api';
+
+const baseURL = `http://localhost:${process.env.PORT || 3000}`;
+
+let userId: string;
+let validApiKey: string;
+let revokedApiKey: string;
+let expiredApiKey: string;
+
+test.describe.serial('API Key Authentication', () => {
+  test.beforeAll(async ({ request }) => {
+    const result = await createTestUserWithApiKey({
+      name: 'auth-test',
+      request,
+    });
+    userId = result.userId;
+    validApiKey = result.apiKey;
+
+    revokedApiKey = await createRevokedApiKey(userId);
+    expiredApiKey = await createExpiredApiKey(userId);
+  });
+
+  test.afterAll(async () => {
+    await cleanupTestUser(userId);
+  });
+
+  test('Valid API key can access protected endpoints', async () => {
+    const ctx = await createApiContext(validApiKey);
+    try {
+      const res = await ctx.get('/api/drafts');
+      expect(res.status()).toBe(200);
+
+      const body = await res.json();
+      expect(body.drafts).toBeInstanceOf(Array);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  test('Revoked API key is rejected with 401', async () => {
+    const ctx = await createApiContext(revokedApiKey);
+    try {
+      const res = await ctx.get('/api/drafts');
+      expect(res.status()).toBe(401);
+
+      const body = await res.json();
+      expect(body.error).toContain('Invalid API key');
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  test('Expired API key is rejected with 401', async () => {
+    const ctx = await createApiContext(expiredApiKey);
+    try {
+      const res = await ctx.get('/api/drafts');
+      expect(res.status()).toBe(401);
+
+      const body = await res.json();
+      expect(body.error).toContain('Invalid API key');
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  test('Request without any auth is rejected with 401', async () => {
+    const ctx = await playwrightRequest.newContext({
+      baseURL,
+      extraHTTPHeaders: { 'Content-Type': 'application/json' },
+    });
+    try {
+      const res = await ctx.get('/api/drafts');
+      expect(res.status()).toBe(401);
+
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  test('Request with invalid Bearer token is rejected with 401', async () => {
+    const ctx = await createApiContext('sk_this_is_completely_fake_and_invalid_key_12345');
+    try {
+      const res = await ctx.get('/api/drafts');
+      expect(res.status()).toBe(401);
+
+      const body = await res.json();
+      expect(body.error).toContain('Invalid API key');
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  test('Request with malformed Authorization header is rejected', async () => {
+    const ctx = await playwrightRequest.newContext({
+      baseURL,
+      extraHTTPHeaders: {
+        Authorization: 'Basic dXNlcjpwYXNz', // Basic auth, not Bearer
+        'Content-Type': 'application/json',
+      },
+    });
+    try {
+      const res = await ctx.get('/api/drafts');
+      expect(res.status()).toBe(401);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  test('API key auth works for creating drafts', async () => {
+    const ctx = await createApiContext(validApiKey);
+    try {
+      const res = await ctx.post('/api/drafts', {
+        data: {
+          title: 'Created via API key',
+          content: '# API Key Test\n\nCreated programmatically.',
+        },
+      });
+
+      expect(res.status()).toBe(200);
+
+      const body = await res.json();
+      expect(body.id).toBeTruthy();
+      expect(body.previewUrl).toBeTruthy();
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  test('API key auth correctly identifies the user', async () => {
+    const ctx = await createApiContext(validApiKey);
+    try {
+      // Create a draft
+      const createRes = await ctx.post('/api/drafts', {
+        data: {
+          title: 'Identity Check',
+          content: 'Verifying user identity.',
+        },
+      });
+      const { id } = await createRes.json();
+
+      // Fetch it back — should work because same user
+      const getRes = await ctx.get(`/api/drafts/${id}`);
+      expect(getRes.status()).toBe(200);
+
+      const draft = await getRes.json();
+      expect(draft.userId).toBe(userId);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  test('Two different users with API keys are isolated', async ({ request }) => {
+    // Create a second user
+    const user2 = await createTestUserWithApiKey({
+      name: 'auth-test-2',
+      request,
+    });
+    const ctx1 = await createApiContext(validApiKey);
+    const ctx2 = await createApiContext(user2.apiKey);
+
+    try {
+      // User 1 creates a draft
+      const createRes = await ctx1.post('/api/drafts', {
+        data: {
+          title: 'User 1 Private Draft',
+          content: 'Only user 1 should see this.',
+        },
+      });
+      const { id } = await createRes.json();
+
+      // User 2 cannot access it
+      const getRes = await ctx2.get(`/api/drafts/${id}`);
+      expect(getRes.status()).toBe(403);
+
+      // User 2 cannot update it
+      const patchRes = await ctx2.patch(`/api/drafts/${id}`, {
+        data: { title: 'Hijacked' },
+      });
+      expect(patchRes.status()).toBe(403);
+
+      // User 2 cannot discard it
+      const discardRes = await ctx2.post(`/api/drafts/${id}/discard`);
+      expect(discardRes.status()).toBe(403);
+    } finally {
+      await ctx1.dispose();
+      await ctx2.dispose();
+      await cleanupTestUser(user2.userId);
+    }
+  });
+});

--- a/tests/routes/drafts.test.ts
+++ b/tests/routes/drafts.test.ts
@@ -1,0 +1,319 @@
+import { expect, test } from '@playwright/test';
+import {
+  createTestUserWithApiKey,
+  createApiContext,
+  cleanupTestUser,
+} from '../helpers-api';
+import type { APIRequestContext } from '@playwright/test';
+
+let aliceUserId: string;
+let aliceApiKey: string;
+let aliceRequest: APIRequestContext;
+
+let bobUserId: string;
+let bobApiKey: string;
+let bobRequest: APIRequestContext;
+
+// Draft IDs created during tests, for cross-test reference
+let aliceDraftId: string;
+
+test.describe.serial('/api/drafts', () => {
+  test.beforeAll(async ({ request }) => {
+    const alice = await createTestUserWithApiKey({ name: 'alice-drafts', request });
+    aliceUserId = alice.userId;
+    aliceApiKey = alice.apiKey;
+    aliceRequest = await createApiContext(alice.apiKey);
+
+    const bob = await createTestUserWithApiKey({ name: 'bob-drafts', request });
+    bobUserId = bob.userId;
+    bobApiKey = bob.apiKey;
+    bobRequest = await createApiContext(bob.apiKey);
+  });
+
+  test.afterAll(async () => {
+    await aliceRequest.dispose();
+    await bobRequest.dispose();
+    await cleanupTestUser(aliceUserId);
+    await cleanupTestUser(bobUserId);
+  });
+
+  // --- CREATE ---
+
+  test('Alice can create a draft', async () => {
+    const res = await aliceRequest.post('/api/drafts', {
+      data: {
+        title: 'Test Article',
+        content: '# Hello\n\nThis is a test article.',
+        description: 'A test description',
+      },
+    });
+
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(body.id).toBeTruthy();
+    expect(body.previewUrl).toContain(`/preview/${body.id}`);
+    expect(body.previewUrl).toContain('watch=true');
+
+    aliceDraftId = body.id;
+  });
+
+  test('Cannot create a draft without title', async () => {
+    const res = await aliceRequest.post('/api/drafts', {
+      data: {
+        content: 'Some content',
+      },
+    });
+
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('required');
+  });
+
+  test('Cannot create a draft without content', async () => {
+    const res = await aliceRequest.post('/api/drafts', {
+      data: {
+        title: 'Missing content',
+      },
+    });
+
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('required');
+  });
+
+  test('Cannot create a draft with empty title', async () => {
+    const res = await aliceRequest.post('/api/drafts', {
+      data: {
+        title: '   ',
+        content: 'Some content',
+      },
+    });
+
+    expect(res.status()).toBe(400);
+  });
+
+  // --- READ ---
+
+  test('Alice can list her drafts', async () => {
+    const res = await aliceRequest.get('/api/drafts');
+
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(body.drafts).toBeInstanceOf(Array);
+    expect(body.drafts.length).toBeGreaterThanOrEqual(1);
+
+    const draft = body.drafts.find(
+      (d: { id: string }) => d.id === aliceDraftId,
+    );
+    expect(draft).toBeTruthy();
+    expect(draft.title).toBe('Test Article');
+    expect(draft.status).toBe('draft');
+  });
+
+  test('Alice can get a specific draft', async () => {
+    const res = await aliceRequest.get(`/api/drafts/${aliceDraftId}`);
+
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(body.id).toBe(aliceDraftId);
+    expect(body.title).toBe('Test Article');
+    expect(body.content).toBe('# Hello\n\nThis is a test article.');
+    expect(body.description).toBe('A test description');
+    expect(body.status).toBe('draft');
+  });
+
+  test('Bob cannot see Alice\'s draft list', async () => {
+    const res = await bobRequest.get('/api/drafts');
+
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    // Bob should have no drafts (or at least not Alice's)
+    const aliceDraft = body.drafts.find(
+      (d: { id: string }) => d.id === aliceDraftId,
+    );
+    expect(aliceDraft).toBeUndefined();
+  });
+
+  test('Bob cannot get Alice\'s draft by ID', async () => {
+    const res = await bobRequest.get(`/api/drafts/${aliceDraftId}`);
+
+    expect(res.status()).toBe(403);
+  });
+
+  test('Getting a non-existent draft returns 404', async () => {
+    const res = await aliceRequest.get(
+      '/api/drafts/00000000-0000-0000-0000-000000000000',
+    );
+
+    expect(res.status()).toBe(404);
+  });
+
+  // --- UPDATE ---
+
+  test('Alice can update her draft title', async () => {
+    const res = await aliceRequest.patch(`/api/drafts/${aliceDraftId}`, {
+      data: { title: 'Updated Title' },
+    });
+
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(body.title).toBe('Updated Title');
+    // Content should not change
+    expect(body.content).toBe('# Hello\n\nThis is a test article.');
+  });
+
+  test('Alice can update her draft content', async () => {
+    const res = await aliceRequest.patch(`/api/drafts/${aliceDraftId}`, {
+      data: { content: '# Updated\n\nNew content here.' },
+    });
+
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(body.content).toBe('# Updated\n\nNew content here.');
+    expect(body.title).toBe('Updated Title');
+  });
+
+  test('Alice can update her draft description', async () => {
+    const res = await aliceRequest.patch(`/api/drafts/${aliceDraftId}`, {
+      data: { description: 'New description' },
+    });
+
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(body.description).toBe('New description');
+  });
+
+  test('Bob cannot update Alice\'s draft', async () => {
+    const res = await bobRequest.patch(`/api/drafts/${aliceDraftId}`, {
+      data: { title: 'Hacked by Bob' },
+    });
+
+    expect(res.status()).toBe(403);
+
+    // Verify Alice's draft is unchanged
+    const check = await aliceRequest.get(`/api/drafts/${aliceDraftId}`);
+    const body = await check.json();
+    expect(body.title).toBe('Updated Title');
+  });
+
+  // --- DISCARD ---
+
+  test('Bob cannot discard Alice\'s draft', async () => {
+    const res = await bobRequest.post(`/api/drafts/${aliceDraftId}/discard`);
+
+    expect(res.status()).toBe(403);
+  });
+
+  test('Alice can discard her draft', async () => {
+    // First create a new draft specifically for discard testing
+    const createRes = await aliceRequest.post('/api/drafts', {
+      data: {
+        title: 'To Be Discarded',
+        content: 'This will be discarded.',
+      },
+    });
+    const { id: discardDraftId } = await createRes.json();
+
+    const res = await aliceRequest.post(`/api/drafts/${discardDraftId}/discard`);
+
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    // Verify status changed
+    const check = await aliceRequest.get(`/api/drafts/${discardDraftId}`);
+    const draft = await check.json();
+    expect(draft.status).toBe('discarded');
+  });
+
+  test('Cannot discard an already discarded draft', async () => {
+    // Create and discard a draft
+    const createRes = await aliceRequest.post('/api/drafts', {
+      data: {
+        title: 'Double Discard',
+        content: 'Try to discard twice.',
+      },
+    });
+    const { id } = await createRes.json();
+
+    await aliceRequest.post(`/api/drafts/${id}/discard`);
+
+    // Try to discard again
+    const res = await aliceRequest.post(`/api/drafts/${id}/discard`);
+
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('already');
+  });
+
+  test('Cannot edit a discarded draft', async () => {
+    // Create and discard
+    const createRes = await aliceRequest.post('/api/drafts', {
+      data: { title: 'Will Discard', content: 'Content' },
+    });
+    const { id } = await createRes.json();
+
+    await aliceRequest.post(`/api/drafts/${id}/discard`);
+
+    // Try to edit
+    const res = await aliceRequest.patch(`/api/drafts/${id}`, {
+      data: { title: 'Edited After Discard' },
+    });
+
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('discarded');
+  });
+
+  // --- PUBLISH (without Intercom configured — tests the validation path) ---
+
+  test('Bob cannot publish Alice\'s draft', async () => {
+    const res = await bobRequest.post(`/api/drafts/${aliceDraftId}/publish`);
+
+    expect(res.status()).toBe(403);
+  });
+
+  test('Cannot publish a discarded draft', async () => {
+    // Create and discard
+    const createRes = await aliceRequest.post('/api/drafts', {
+      data: { title: 'Discard Before Publish', content: 'Content' },
+    });
+    const { id } = await createRes.json();
+    await aliceRequest.post(`/api/drafts/${id}/discard`);
+
+    const res = await aliceRequest.post(`/api/drafts/${id}/publish`);
+
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('already');
+  });
+
+  // --- DESCRIPTION LIMITS ---
+
+  test('Description is trimmed to 255 characters on create', async () => {
+    const longDesc = 'A'.repeat(300);
+
+    const res = await aliceRequest.post('/api/drafts', {
+      data: {
+        title: 'Long Description',
+        content: 'Content',
+        description: longDesc,
+      },
+    });
+
+    expect(res.status()).toBe(200);
+
+    const { id } = await res.json();
+    const check = await aliceRequest.get(`/api/drafts/${id}`);
+    const draft = await check.json();
+    expect(draft.description.length).toBeLessThanOrEqual(255);
+  });
+});


### PR DESCRIPTION
## Summary

- **Per-user API key system**: Users generate/revoke keys from `/settings`. Keys are SHA-256 hashed — plaintext shown once. Middleware validates `Bearer` tokens on `/api/*` routes (edge-compatible).
- **Article draft CRUD API**: REST endpoints at `/api/drafts` with ownership verification on all mutations.
- **Preview page**: Public page at `/preview/[id]` renders markdown articles. Supports live polling (`?watch=true`), in-browser editing, and Intercom save flow.
- **Intercom publish with collection selection**: Publish dialog lets users pick a collection (folder), author, and SEO description before saving the draft to Intercom.
- **AI-generated descriptions**: The `POST /api/drafts` endpoint accepts a `description` field (max 255 chars) so the future CLI skill can generate SEO descriptions at draft creation time. The description flows through the entire pipeline: DB → preview page → publish dialog → Intercom meta description.

## What changed since initial PR

- **Collection + author selection on publish**: Preview page now shows a dialog with collection tree selector, author dropdown, and description field (pre-filled from draft)
- **Copy update**: "Publish to Intercom" → "Save draft to Intercom" (articles are saved as drafts in Intercom for CS review)
- **URL bug fix**: Fixed operator precedence bug where `NEXT_PUBLIC_APP_URL` was ignored when `VERCEL_URL` was also set
- **Lint fix**: Escaped apostrophe in api-keys-manager that broke Vercel build
- **`.env.example`**: Added `INTERCOM_ACCESS_TOKEN` and `INTERCOM_WORKSPACE_ID`

## Security — review requested

### API Key Design
| Aspect | Implementation |
|--------|---------------|
| Key generation | `crypto.randomBytes(32)` → 256 bits entropy, `sk_` prefix |
| Storage | SHA-256 hash only — plaintext never stored |
| Middleware validation | Web Crypto API for hashing, `@vercel/postgres` for DB lookup |
| Identity passing | Middleware sets `x-api-key-user-id` header → `getAuthenticatedUser()` reads it |
| Revocation | `revokedAt` timestamp checked on every validation |

### Draft ownership checks
All mutation endpoints verify `draft.userId === authenticatedUser` → 403 if mismatch:
- `GET /api/drafts/[id]`, `PATCH /api/drafts/[id]`
- `POST /api/drafts/[id]/publish`, `POST /api/drafts/[id]/discard`

## Test coverage (29 tests, all passing)

**API Key Auth (9 tests):** valid key, revoked key, expired key, no auth, fake key, malformed header, create via key, user identity, user isolation

**Article Drafts (20 tests):** CRUD, validation, ownership checks (Bob can't access Alice's drafts), status transitions, double-discard, edit-after-discard, publish-after-discard, description limits

## Files changed

### New files
| File | Purpose |
|------|---------|
| `lib/auth-helpers.ts` | `getAuthenticatedUser()` — checks API key then session |
| `lib/db/middleware-queries.ts` | Edge-compatible API key validation |
| `app/(chat)/api/api-keys/route.ts` | API key CRUD (session-auth only) |
| `app/(chat)/settings/page.tsx` | Settings page with API key manager |
| `components/api-keys-manager.tsx` | Key management UI |
| `app/api/drafts/route.ts` | List/create drafts |
| `app/api/drafts/[id]/route.ts` | Get/update draft |
| `app/api/drafts/[id]/publish/route.ts` | Save draft to Intercom (with collection/author) |
| `app/api/drafts/[id]/discard/route.ts` | Discard draft |
| `app/preview/[id]/page.tsx` | Public preview page |
| `components/preview-client.tsx` | Preview UI with edit, publish dialog, polling |
| `tests/helpers-api.ts` | Test helper for creating users + API keys in DB |
| `tests/routes/drafts.test.ts` | 20 draft endpoint tests |
| `tests/routes/api-key-auth.test.ts` | 9 API key auth tests |

### Modified files
| File | Change |
|------|--------|
| `lib/db/schema.ts` | Added ApiKey and ArticleDraft tables |
| `lib/db/queries.ts` | Added CRUD functions for API keys and drafts |
| `lib/api-key.ts` | Key generation/hashing utilities |
| `middleware.ts` | API key Bearer token validation |
| `components/sidebar-user-nav.tsx` | Added "API Keys" settings link |
| `.env.example` | Added Intercom + Google OAuth vars |

## Test plan

- [ ] Create API key from `/settings`, verify shown once
- [ ] `curl -H "Authorization: Bearer sk_..."` against `/api/drafts` — works
- [ ] Revoke key, retry — 401
- [ ] Create draft via API with title, content, and description
- [ ] Open preview URL, verify content renders with description
- [ ] Click "Save draft to Intercom" — select collection, author, verify description pre-filled
- [ ] Save — verify draft article created in Intercom in correct collection
- [ ] Try accessing another user's draft — 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)