### PR TITLE
Add auth to preview page

### DIFF
--- a/app/preview/[id]/page.tsx
+++ b/app/preview/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { getArticleDraft } from '@/lib/db/queries';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { PreviewClient } from '@/components/preview-client';
 import { auth } from '@/app/(auth)/auth';
 import { db } from '@/lib/db/queries';
@@ -14,7 +14,19 @@ export default async function PreviewPage({
   const { id } = await params;
   const [draft, session] = await Promise.all([getArticleDraft({ id }), auth()]);
 
+  if (!session?.user?.id) {
+    redirect('/login');
+  }
+
   if (!draft) {
+    notFound();
+  }
+
+  // Draft and discarded articles are only visible to the author
+  if (
+    (draft.status === 'draft' || draft.status === 'discarded') &&
+    draft.userId !== session.user.id
+  ) {
     notFound();
   }
 


### PR DESCRIPTION
## Summary
- Require login to view preview pages (redirect to `/login` if unauthenticated)
- `draft` and `discarded` articles only visible to the author
- `pending_review` and `published` articles visible to any authenticated user (needed for review workflow)

This was part of PR #20 but the commit was pushed after the squash merge.

## Test plan
- [ ] Unauthenticated visit to `/preview/:id` redirects to `/login`
- [ ] Author can see their own drafts
- [ ] Other authenticated users cannot see someone else's draft-status articles
- [ ] Any authenticated user can see `pending_review` articles

🤖 Generated with [Claude Code](https://claude.com/claude-code)