### PR TITLE
Add auth to all Notion API routes

### DIFF
--- a/app/api/notion/content/route.ts
+++ b/app/api/notion/content/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { notionService } from '@/lib/notion/client';
+import { getAuthenticatedUser } from '@/lib/auth-helpers';
 
 interface ContentRequest {
   pageIds: string[];
@@ -19,6 +20,11 @@ interface ContentResponse {
 }
 
 export async function POST(request: NextRequest) {
+  const authResult = await getAuthenticatedUser();
+  if (!authResult) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   try {
     const body: ContentRequest = await request.json();
     const { pageIds } = body;

--- a/app/api/notion/export/route.ts
+++ b/app/api/notion/export/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { notionExporter } from '@/lib/notion/export';
-import { auth } from '@/app/(auth)/auth';
+import { getAuthenticatedUser } from '@/lib/auth-helpers';
 
 interface ExportRequest {
   title: string;
@@ -11,9 +11,8 @@ interface ExportRequest {
 
 export async function POST(request: NextRequest) {
   try {
-    // Check authentication
-    const session = await auth();
-    if (!session?.user) {
+    const authResult = await getAuthenticatedUser();
+    if (!authResult) {
       return NextResponse.json(
         { success: false, error: 'Unauthorized' },
         { status: 401 },
@@ -84,9 +83,8 @@ export async function POST(request: NextRequest) {
 
 export async function GET(request: NextRequest) {
   try {
-    // Check authentication
-    const session = await auth();
-    if (!session?.user) {
+    const authResult = await getAuthenticatedUser();
+    if (!authResult) {
       return NextResponse.json(
         { success: false, error: 'Unauthorized' },
         { status: 401 },

--- a/app/api/notion/pages/route.ts
+++ b/app/api/notion/pages/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { notionService, type NotionPage } from '@/lib/notion/client';
+import { getAuthenticatedUser } from '@/lib/auth-helpers';
 
 interface CachedResult {
   pages: NotionPage[];
@@ -42,6 +43,11 @@ function filterCachedPages(pages: NotionPage[], query: string): NotionPage[] {
 }
 
 export async function GET(request: NextRequest) {
+  const authResult = await getAuthenticatedUser();
+  if (!authResult) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   try {
     const { searchParams } = new URL(request.url);
     const query = searchParams.get('q') || searchParams.get('query') || '';
@@ -181,6 +187,11 @@ export async function GET(request: NextRequest) {
 
 // Test endpoint to verify connection
 export async function POST(request: NextRequest) {
+  const authResult = await getAuthenticatedUser();
+  if (!authResult) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   try {
     const isConnected = await notionService.testConnection();
 


### PR DESCRIPTION
## Summary
- `/api/notion/content` (POST) — had zero auth, now requires `getAuthenticatedUser()`
- `/api/notion/pages` (GET, POST) — had zero auth, now requires `getAuthenticatedUser()`
- `/api/notion/export` (POST, GET) — migrated from `auth()` to `getAuthenticatedUser()` for consistency and MCP JWT support

These routes exposed internal Notion data to anyone who could get past middleware.

## Test plan
- [ ] Unauthenticated requests to `/api/notion/*` return 401
- [ ] Notion selector modal still works for logged-in users
- [ ] Notion export still works for logged-in users

🤖 Generated with [Claude Code](https://claude.com/claude-code)