### PR TITLE
Security: Restrict MCP client registration to same-origin redirect URIs

### DIFF
--- a/app/api/mcp/register/route.ts
+++ b/app/api/mcp/register/route.ts
@@ -2,6 +2,66 @@ import { NextResponse } from 'next/server';
 import { db } from '@/lib/db/queries';
 import { mcpOAuthClient } from '@/lib/db/schema';
 
+const BASE_URL =
+  process.env.NEXT_PUBLIC_APP_URL ||
+  'https://product-documentation-generator.vercel.app';
+
+/**
+ * Returns the set of allowed origins for redirect URIs.
+ * Includes the configured app URL and, for Vercel preview deployments,
+ * the VERCEL_URL if available.
+ */
+function getAllowedOrigins(): URL[] {
+  const origins: URL[] = [new URL(BASE_URL)];
+
+  // In local development, also allow localhost variants
+  if (BASE_URL.includes('localhost') || BASE_URL.includes('127.0.0.1')) {
+    try {
+      const localUrl = new URL(BASE_URL);
+      if (localUrl.protocol === 'http:') {
+        origins.push(new URL(`https://${localUrl.host}`));
+      }
+    } catch {
+      // ignore parse errors
+    }
+  }
+
+  // Support Vercel preview deployment URLs
+  if (process.env.VERCEL_URL) {
+    try {
+      origins.push(new URL(`https://${process.env.VERCEL_URL}`));
+    } catch {
+      // ignore parse errors
+    }
+  }
+
+  return origins;
+}
+
+/**
+ * Validates that a redirect URI's origin matches one of the allowed app origins.
+ * This prevents attackers from registering clients that redirect to external domains.
+ */
+function isAllowedRedirectUri(uri: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return false;
+  }
+
+  // Only allow http/https schemes
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return false;
+  }
+
+  const allowedOrigins = getAllowedOrigins();
+  return allowedOrigins.some(
+    (allowed) =>
+      parsed.hostname === allowed.hostname && parsed.port === allowed.port,
+  );
+}
+
 export async function POST(request: Request) {
   let body: Record<string, unknown>;
   try {
@@ -16,6 +76,30 @@ export async function POST(request: Request) {
   const clientName = (body.client_name as string) || 'Unknown Client';
   const redirectUris = (body.redirect_uris as string[]) || [];
   const grantTypes = (body.grant_types as string[]) || ['authorization_code'];
+
+  // Validate that all redirect URIs point to this application's domain.
+  // This prevents attackers from registering clients with external redirect URIs
+  // that could be used to steal authorization codes.
+  if (redirectUris.length === 0) {
+    return NextResponse.json(
+      {
+        error: 'invalid_client_metadata',
+        error_description: 'At least one redirect_uri is required',
+      },
+      { status: 400 },
+    );
+  }
+
+  const invalidUris = redirectUris.filter((uri) => !isAllowedRedirectUri(uri));
+  if (invalidUris.length > 0) {
+    return NextResponse.json(
+      {
+        error: 'invalid_redirect_uri',
+        error_description: `redirect_uris must point to this application's domain (${new URL(BASE_URL).hostname}). Invalid URIs: ${invalidUris.join(', ')}`,
+      },
+      { status: 400 },
+    );
+  }
 
   // Generate a random client_id
   const clientId = crypto.randomUUID();


### PR DESCRIPTION
## Summary
- **Vulnerability**: The `/api/mcp/register` POST endpoint accepted arbitrary `redirect_uris`, allowing attackers to register OAuth clients pointing to external domains and steal authorization codes via the OAuth callback flow.
- **Fix**: Added redirect URI validation that requires all registered `redirect_uris` to match the application's own hostname (`NEXT_PUBLIC_APP_URL`, `VERCEL_URL` for preview deployments, or `localhost` for development).
- Rejects registrations with no redirect URIs, unparseable URIs, non-HTTP(S) schemes, or URIs pointing to external domains.

## How it works
- `getAllowedOrigins()` builds a list of allowed hostnames from the app's configured URLs
- `isAllowedRedirectUri()` validates each URI against that allowlist by comparing hostname and port
- The existing MCP OAuth flow (Claude Code registration + Google OAuth dance) continues to work because Claude Code uses the app's own domain for its redirect URI

## Test plan
- [ ] Verify Claude Code can still complete the MCP OAuth flow (register client -> authorize -> callback -> token)
- [ ] Verify that a POST to `/api/mcp/register` with an external redirect URI (e.g., `https://evil.com/callback`) returns a 400 error
- [ ] Verify that a POST with no `redirect_uris` returns a 400 error
- [ ] Verify that a POST with the app's own domain redirect URI succeeds (201)

🤖 Generated with [Claude Code](https://claude.com/claude-code)