### PR TITLE
Block editing published drafts via MCP

### DIFF
--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -158,7 +158,7 @@ export function registerTools(server: McpServer, userId: string) {
           isError: true,
         };
       }
-      if (draft.status === 'discarded' || draft.status === 'pending_review') {
+      if (draft.status !== 'draft') {
         return {
           content: [
             {


### PR DESCRIPTION
## Summary
- MCP `update_draft` tool now only allows editing drafts with `status === 'draft'`
- Previously it blocked `discarded` and `pending_review` but missed `published`, allowing local DB to diverge from Intercom
- Matches the HTTP PATCH route which already uses `if (draft.status !== 'draft')`

## Test plan
- [ ] Can still edit draft-status articles via MCP
- [ ] Cannot edit published/pending_review/discarded articles via MCP
- [ ] Error message correctly shows the current status

🤖 Generated with [Claude Code](https://claude.com/claude-code)