### PR TITLE
Fix null check in chat DELETE and error handling in submit-for-review

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -481,6 +481,10 @@ export async function DELETE(request: Request) {
 
   const chat = await getChatById({ id });
 
+  if (!chat) {
+    return new ChatSDKError('not_found:chat').toResponse();
+  }
+
   if (chat.userId !== session.user.id) {
     return new ChatSDKError('forbidden:chat').toResponse();
   }

--- a/app/api/drafts/[id]/submit-for-review/route.ts
+++ b/app/api/drafts/[id]/submit-for-review/route.ts
@@ -48,13 +48,17 @@ export async function POST(
     process.env.NEXT_PUBLIC_APP_URL ||
     'https://product-documentation-generator.vercel.app';
 
-  // Notify CS in Slack
-  await notifySlackForReview({
-    title: draft.title,
-    submittedBy: authResult.userEmail ?? authResult.userId,
-    reviewUrl: `${baseUrl}/preview/${draft.id}`,
-    reviewerSlackId,
-  });
+  // Notify CS in Slack (don't fail the request if Slack is down)
+  try {
+    await notifySlackForReview({
+      title: draft.title,
+      submittedBy: authResult.userEmail ?? authResult.userId,
+      reviewUrl: `${baseUrl}/preview/${draft.id}`,
+      reviewerSlackId,
+    });
+  } catch (err) {
+    console.error('Failed to notify Slack for review:', err);
+  }
 
   return Response.json({ success: true, status: 'pending_review' });
 }


### PR DESCRIPTION
## Summary
- **Chat DELETE handler**: Add null check for `chat` object before accessing `.userId`. Previously, deleting a non-existent chat would crash with `TypeError: Cannot read properties of null (reading 'userId')` instead of returning 404. This matches the existing pattern in the POST handler.
- **Submit-for-review route**: Wrap `notifySlackForReview()` in try/catch with `console.error`, so a Slack failure doesn't return 500 after the DB has already been updated to `pending_review`. This matches the existing pattern in the `request-changes` route.

## Test plan
- [ ] DELETE `/api/chat?id=nonexistent-id` returns 404 instead of crashing
- [ ] DELETE `/api/chat?id=valid-id` still works as before
- [ ] POST `/api/drafts/:id/submit-for-review` succeeds even if Slack webhook is down
- [ ] POST `/api/drafts/:id/submit-for-review` still sends Slack notification when Slack is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)