### PR TITLE
Fix auth code TOCTOU race condition

### DIFF
--- a/app/api/mcp/token/route.ts
+++ b/app/api/mcp/token/route.ts
@@ -64,17 +64,18 @@ async function handleAuthorizationCode(body: URLSearchParams) {
     );
   }
 
-  // Look up the auth code
+  // Atomically claim the auth code (prevents TOCTOU race condition)
   const [authCodeRow] = await db
-    .select()
-    .from(mcpAuthCode)
+    .update(mcpAuthCode)
+    .set({ usedAt: new Date() })
     .where(
       and(
         eq(mcpAuthCode.code, code),
         isNull(mcpAuthCode.usedAt),
         gt(mcpAuthCode.expiresAt, new Date()),
       ),
-    );
+    )
+    .returning();
 
   if (!authCodeRow || !authCodeRow.userId) {
     return NextResponse.json({ error: 'invalid_grant' }, { status: 400 });
@@ -90,12 +91,6 @@ async function handleAuthorizationCode(body: URLSearchParams) {
   if (computedChallenge !== authCodeRow.codeChallenge) {
     return NextResponse.json({ error: 'invalid_grant' }, { status: 400 });
   }
-
-  // Mark code as used
-  await db
-    .update(mcpAuthCode)
-    .set({ usedAt: new Date() })
-    .where(eq(mcpAuthCode.id, authCodeRow.id));
 
   const audience = authCodeRow.resource || `${BASE_URL}/api/mcp`;
   const scope = authCodeRow.scope || 'drafts';


### PR DESCRIPTION
## Summary
- Replace two-step SELECT + UPDATE in MCP token endpoint with atomic `UPDATE...WHERE...RETURNING`
- Prevents concurrent requests from exchanging the same authorization code for multiple tokens
- All existing validation (expiry, userId, redirect_uri, PKCE) is preserved

## Test plan
- [ ] MCP OAuth token exchange still works (single use)
- [ ] Using an already-used code returns `invalid_grant`
- [ ] Using an expired code returns `invalid_grant`
- [ ] PKCE verification still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)