### PR TITLE
Allow localhost redirect URIs for CLI OAuth clients

### DIFF
--- a/app/api/mcp/register/route.ts
+++ b/app/api/mcp/register/route.ts
@@ -55,6 +55,13 @@ function isAllowedRedirectUri(uri: string): boolean {
     return false;
   }
 
+  // Allow localhost/127.0.0.1 redirect URIs on any port.
+  // This is standard for CLI-based OAuth clients (RFC 8252 Section 7.3)
+  // which spin up a temporary local HTTP server to receive the callback.
+  if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
+    return true;
+  }
+
   const allowedOrigins = getAllowedOrigins();
   return allowedOrigins.some(
     (allowed) =>


### PR DESCRIPTION
## Summary
PR #23 restricted MCP client registration to same-origin redirect URIs, which is correct for preventing open redirects. However, it broke CLI-based OAuth clients like Claude Code, which use `http://localhost:<port>/callback` as the redirect URI (per [RFC 8252 Section 7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3)).

This fix allows `localhost` and `127.0.0.1` redirect URIs on any port, while still blocking external domains.

## Test plan
- [ ] Claude Code can authenticate with the MCP server (`/mcp` → Authenticate)
- [ ] External redirect URIs (e.g., `https://evil.com/callback`) are still rejected
- [ ] The app's own domain redirect URIs still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)