### PR TITLE
Add structured logging to Slack notifications

### DIFF
--- a/app/api/drafts/[id]/request-changes/route.ts
+++ b/app/api/drafts/[id]/request-changes/route.ts
@@ -1,8 +1,11 @@
 import { getAuthenticatedUser } from '@/lib/auth-helpers';
 import { db, getArticleDraft, updateArticleDraft } from '@/lib/db/queries';
 import { user as userTable } from '@/lib/db/schema';
-import { eq } from 'drizzle-orm';
+import { createLogger } from '@/lib/logger';
 import { notifyAuthorChangesRequested } from '@/lib/slack/notify-author';
+import { eq } from 'drizzle-orm';
+
+const log = createLogger('api');
 
 export async function POST(
   request: Request,
@@ -50,25 +53,34 @@ export async function POST(
     .from(userTable)
     .where(eq(userTable.id, draft.userId));
 
+  let slackNotified = false;
+
   if (author?.email) {
     const baseUrl =
       process.env.NEXT_PUBLIC_APP_URL ||
       'https://product-documentation-generator.vercel.app';
 
-    try {
-      await notifyAuthorChangesRequested({
-        authorEmail: author.email,
-        articleTitle: draft.title,
-        reviewUrl: `${baseUrl}/preview/${draft.id}`,
-        note,
-        reviewerName: authResult.userEmail ?? undefined,
-      });
-    } catch (err) {
-      console.error('Failed to notify author via Slack:', err);
+    const slackResult = await notifyAuthorChangesRequested({
+      authorEmail: author.email,
+      articleTitle: draft.title,
+      reviewUrl: `${baseUrl}/preview/${draft.id}`,
+      note,
+      reviewerName: authResult.userEmail ?? undefined,
+    });
+
+    slackNotified = slackResult.ok;
+    if (!slackResult.ok) {
+      log.warn(
+        { draftId: draft.id, authorEmail: author.email },
+        `Author notification skipped: ${slackResult.reason}`,
+      );
     }
   } else {
-    console.warn(`No email found for author userId=${draft.userId}`);
+    log.warn(
+      { userId: draft.userId, draftId: draft.id },
+      'No email found for author',
+    );
   }
 
-  return Response.json({ success: true, status: 'draft' });
+  return Response.json({ success: true, status: 'draft', slackNotified });
 }

--- a/app/api/drafts/[id]/submit-for-review/route.ts
+++ b/app/api/drafts/[id]/submit-for-review/route.ts
@@ -1,6 +1,9 @@
 import { getAuthenticatedUser } from '@/lib/auth-helpers';
 import { getArticleDraft, updateArticleDraft } from '@/lib/db/queries';
+import { createLogger } from '@/lib/logger';
 import { notifySlackForReview } from '@/lib/slack/notify-review';
+
+const log = createLogger('api');
 
 export async function POST(
   request: Request,
@@ -49,16 +52,20 @@ export async function POST(
     'https://product-documentation-generator.vercel.app';
 
   // Notify CS in Slack (don't fail the request if Slack is down)
-  try {
-    await notifySlackForReview({
-      title: draft.title,
-      submittedBy: authResult.userEmail ?? authResult.userId,
-      reviewUrl: `${baseUrl}/preview/${draft.id}`,
-      reviewerSlackId,
-    });
-  } catch (err) {
-    console.error('Failed to notify Slack for review:', err);
+  const slackResult = await notifySlackForReview({
+    title: draft.title,
+    submittedBy: authResult.userEmail ?? authResult.userId,
+    reviewUrl: `${baseUrl}/preview/${draft.id}`,
+    reviewerSlackId,
+  });
+
+  if (!slackResult.ok) {
+    log.warn({ draftId: draft.id }, `Slack notification skipped: ${slackResult.reason}`);
   }
 
-  return Response.json({ success: true, status: 'pending_review' });
+  return Response.json({
+    success: true,
+    status: 'pending_review',
+    slackNotified: slackResult.ok,
+  });
 }

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -250,7 +250,7 @@ export function registerTools(server: McpServer, userId: string) {
         .where(eq(userTable.id, userId));
 
       // Notify CS in Slack
-      await notifySlackForReview({
+      const slackResult = await notifySlackForReview({
         title: draft.title,
         submittedBy: dbUser?.email ?? userId,
         reviewUrl,
@@ -265,6 +265,8 @@ export function registerTools(server: McpServer, userId: string) {
               success: true,
               status: 'pending_review',
               reviewUrl,
+              slackNotified: slackResult.ok,
+              ...(slackResult.ok ? {} : { slackWarning: slackResult.reason }),
             }),
           },
         ],

--- a/lib/slack/notify-author.ts
+++ b/lib/slack/notify-author.ts
@@ -1,3 +1,11 @@
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('slack');
+
+export type SlackAuthorNotifyResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
 /**
  * Send a Slack DM to the article author when changes are requested.
  * Looks up the author's Slack user ID by email, opens a DM channel, and posts a message.
@@ -14,11 +22,12 @@ export async function notifyAuthorChangesRequested({
   reviewUrl: string;
   note?: string;
   reviewerName?: string;
-}) {
+}): Promise<SlackAuthorNotifyResult> {
   const token = process.env.SLACK_BOT_TOKEN;
   if (!token) {
-    console.warn('SLACK_BOT_TOKEN not configured, skipping author notification');
-    return;
+    const reason = 'SLACK_BOT_TOKEN not configured';
+    log.warn(reason);
+    return { ok: false, reason };
   }
 
   // Look up Slack user by email (requires users:read.email scope)
@@ -29,10 +38,9 @@ export async function notifyAuthorChangesRequested({
   const lookupData = await lookupRes.json();
 
   if (!lookupData.ok) {
-    console.warn(
-      `Slack lookupByEmail failed for ${authorEmail}: ${lookupData.error}`,
-    );
-    return;
+    const reason = `Slack lookupByEmail failed for ${authorEmail}: ${lookupData.error}`;
+    log.warn({ authorEmail }, reason);
+    return { ok: false, reason };
   }
 
   const slackUserId = lookupData.user.id;
@@ -49,8 +57,9 @@ export async function notifyAuthorChangesRequested({
 
   const openData = await openRes.json();
   if (!openData.ok) {
-    console.error('Failed to open Slack DM:', openData.error);
-    return;
+    const reason = `Failed to open Slack DM: ${openData.error}`;
+    log.error({ slackUserId }, reason);
+    return { ok: false, reason };
   }
 
   const channelId = openData.channel.id;
@@ -87,6 +96,11 @@ export async function notifyAuthorChangesRequested({
 
   const msgData = await msgRes.json();
   if (!msgData.ok) {
-    console.error('Failed to send Slack DM:', msgData.error);
+    const reason = `Failed to send Slack DM: ${msgData.error}`;
+    log.error({ channelId }, reason);
+    return { ok: false, reason };
   }
+
+  log.info({ authorEmail, articleTitle }, 'Author notified of changes requested');
+  return { ok: true };
 }

--- a/lib/slack/notify-review.ts
+++ b/lib/slack/notify-review.ts
@@ -1,3 +1,11 @@
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('slack');
+
+export type SlackNotifyResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
 export async function notifySlackForReview({
   title,
   submittedBy,
@@ -8,13 +16,12 @@ export async function notifySlackForReview({
   submittedBy: string;
   reviewUrl: string;
   reviewerSlackId?: string;
-}) {
+}): Promise<SlackNotifyResult> {
   const webhookUrl = process.env.SLACK_REVIEW_WEBHOOK_URL;
   if (!webhookUrl) {
-    console.warn(
-      'SLACK_REVIEW_WEBHOOK_URL not configured, skipping notification',
-    );
-    return;
+    const reason = 'SLACK_REVIEW_WEBHOOK_URL not configured';
+    log.warn(reason);
+    return { ok: false, reason };
   }
 
   const reviewerMention = reviewerSlackId ? `<@${reviewerSlackId}> ` : '';
@@ -45,9 +52,17 @@ export async function notifySlackForReview({
     });
 
     if (!res.ok) {
-      console.error('Slack notification failed:', res.status, await res.text());
+      const body = await res.text();
+      const reason = `Slack webhook returned ${res.status}: ${body}`;
+      log.error({ status: res.status }, reason);
+      return { ok: false, reason };
     }
+
+    log.info({ title, submittedBy }, 'Review notification sent');
+    return { ok: true };
   } catch (error) {
-    console.error('Slack notification error:', error);
+    const reason = error instanceof Error ? error.message : String(error);
+    log.error({ err: error, title }, 'Failed to send review notification');
+    return { ok: false, reason };
   }
 }


### PR DESCRIPTION
## Summary
- Replace `console.error`/`console.warn` with pino structured logging in `notify-review.ts` and `notify-author.ts`
- Both Slack notification functions now return typed results (`SlackNotifyResult` / `SlackAuthorNotifyResult`) instead of `void`, enabling callers to surface failures
- API routes (`submit-for-review`, `request-changes`) and MCP `submit_for_review` tool now include `slackNotified` in responses so clients know if the notification succeeded
- Failures are logged with structured context (draft ID, email, status code) instead of raw `console.error` strings

## Test plan
- [ ] Submit a draft for review without `SLACK_REVIEW_WEBHOOK_URL` set — verify `slackNotified: false` in response and structured log warning
- [ ] Submit with webhook configured — verify `slackNotified: true` and `log.info` fires
- [ ] Request changes without `SLACK_BOT_TOKEN` — verify graceful degradation with `slackNotified: false`
- [ ] Use MCP `submit_for_review` tool — verify `slackWarning` field appears when Slack is unconfigured

🤖 Generated with [Claude Code](https://claude.com/claude-code)