### PR TITLE
Fix OAuthAccountNotLinked error for MCP-authenticated users

### DIFF
--- a/app/api/mcp/callback/route.ts
+++ b/app/api/mcp/callback/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/db/queries';
-import { mcpAuthCode, user } from '@/lib/db/schema';
-import { eq } from 'drizzle-orm';
+import { account, mcpAuthCode, user } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
 import { cookies } from 'next/headers';
 
 const BASE_URL =
@@ -118,6 +118,35 @@ export async function GET(request: Request) {
       })
       .returning();
     userId = newUser.id;
+  }
+
+  // Ensure a Google Account row exists so NextAuth can link this user
+  // when they later sign in via the web app (prevents OAuthAccountNotLinked)
+  const [existingAccount] = await db
+    .select()
+    .from(account)
+    .where(
+      and(
+        eq(account.provider, 'google'),
+        eq(account.providerAccountId, userInfo.id),
+      ),
+    );
+
+  if (!existingAccount) {
+    await db.insert(account).values({
+      userId,
+      type: 'oidc',
+      provider: 'google',
+      providerAccountId: userInfo.id,
+      access_token: tokenData.access_token,
+      refresh_token: tokenData.refresh_token ?? null,
+      expires_at: tokenData.expires_in
+        ? Math.floor(Date.now() / 1000) + tokenData.expires_in
+        : null,
+      token_type: tokenData.token_type ?? null,
+      scope: tokenData.scope ?? null,
+      id_token: tokenData.id_token ?? null,
+    });
   }
 
   // Generate the actual authorization code


### PR DESCRIPTION
## Summary
- MCP OAuth callback created `User` rows but not `Account` rows, causing NextAuth to reject web app sign-in with `OAuthAccountNotLinked`
- Now creates the Google `Account` row during MCP authentication so users can seamlessly sign into the web app afterward
- Existing affected users are fixed automatically on their next MCP re-authentication

## Test plan
- [ ] Authenticate via MCP flow as a new user, then sign into the web app — should succeed
- [ ] Authenticate via web app first, then via MCP — should still work (no duplicate Account rows)
- [ ] Verify existing MCP-only users can sign into web app after re-authenticating via MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)